### PR TITLE
Update ephemeralrunner cleanup script for failures reported

### DIFF
--- a/ci/cluster/oci/hacks/ephemeralrunner-cleanup-cj.yaml
+++ b/ci/cluster/oci/hacks/ephemeralrunner-cleanup-cj.yaml
@@ -49,7 +49,19 @@ spec:
             - /bin/bash
             args:
             - -c
-            - for i in $(kubectl -n arc-systems get ephemeralrunners -o jsonpath="{range .items[?(@.status.phase=='Failed')]}{.metadata.name}{'\n'}{end}"); do kubectl -n arc-systems delete ephemeralrunner ${i}; done
+            - |
+              echo "Deleting EphemeralRunners in Failed State..." && \
+              for i in $(kubectl -n arc-systems get ephemeralrunners -o jsonpath="{range .items[?(@.status.phase=='Failed')]}{.metadata.name}{'\n'}{end}"); \
+              do \
+                kubectl -n arc-systems delete ephemeralrunner ${i}; \
+              done && \
+              echo "Done..." && \
+              echo "Deleting EphemeralRunners with Failures in Status" && \
+              for j in $(kubectl get ephemeralrunners -n arc-systems -o json | jq -r '.items[] | select(.status.failures != null) | .metadata.name'); \
+              do \
+                kubectl -n arc-systems delete ephemeralrunner ${j}; \
+              done && \
+              echo "Done..."
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
While checking with @mfahlandt , we noticed that failures are reported in the EphemeralRunners, e.g.:

```bash
k get ephemeralrunners -n arc-systems  -o json | jq -r '.items[].status | del(.runnerJITConfig) | del(.runnerId)'
...
{
  "jobRepositoryName": "open-telemetry/opentelemetry-java-instrumentation",
  "jobWorkflowRef": "open-telemetry/opentelemetry-java-instrumentation/.github/workflows/codeql.yml@refs/pull/14271/merge",
  "phase": "Running",
  "ready": true,
  "runnerName": "oracle-8cpu-32gb-x86-64-5bmz9-runner-qtzbf"
}
{
  "failures": {
    "6bd04731-a832-4434-aa96-9f169845b87d": true
  },
  "jobRepositoryName": "strimzi/strimzi-kafka-operator",
  "jobWorkflowRef": "strimzi/strimzi-kafka-operator/.github/workflows/run-system-tests.yml@refs/pull/11331/merge",
  "phase": "Running",
  "ready": true,
  "runnerName": "oracle-vm-8cpu-32gb-arm64-rjrc8-runner-58hqr"
}
{
  "failures": {
    "ceb72bef-6d80-49bd-83cd-de223b8263d1": true
  },
  "jobRepositoryName": "strimzi/strimzi-kafka-operator",
  "jobWorkflowRef": "strimzi/strimzi-kafka-operator/.github/workflows/run-system-tests.yml@refs/pull/11331/merge",
  "phase": "Running",
  "ready": true,
  "runnerName": "oracle-vm-8cpu-32gb-x86-64-65f5h-runner-48q7v"
}
```

I updated to CronJob to cleanup those jobs as well.