### PR TITLE
Fix: labeler args robustness, people insertion logic, and cartopy transform

### DIFF
--- a/Ambassadors/CNCFInsertAmbassadorInPeople_json.py
+++ b/Ambassadors/CNCFInsertAmbassadorInPeople_json.py
@@ -279,6 +279,7 @@ def process_entries(firstLine, lastLine):
 
                 # Insert new person in sorted order
                 indexPeople = 0
+                inserted = False
                 for people in data:
                     if people["name"].lower() < newPerson.name.lower():
                         indexPeople += 1
@@ -290,7 +291,14 @@ def process_entries(firstLine, lastLine):
                         data.insert(indexPeople, json.JSONDecoder(object_pairs_hook=OrderedDict).decode(newPerson.toJSON()))
                         split_tup = os.path.splitext(newPerson.image)
                         os.rename("imageTemp" + split_tup[1], "../../people/images/" + newPerson.image)
+                        inserted = True
                         break
+
+                if not inserted:
+                    # Append to end if new name sorts after all existing entries
+                    data.append(json.JSONDecoder(object_pairs_hook=OrderedDict).decode(newPerson.toJSON()))
+                    split_tup = os.path.splitext(newPerson.image)
+                    os.rename("imageTemp" + split_tup[1], "../../people/images/" + newPerson.image)
 
                 # Write updated data back to file
                 with open(PEOPLE_JSON_PATH, "w", encoding='utf-8') as jsonfile:

--- a/Kubestronaut/CNCFInsertKubestronautInPeople_json.py
+++ b/Kubestronaut/CNCFInsertKubestronautInPeople_json.py
@@ -176,22 +176,20 @@ for lineToBeInserted in range(firstLineToBeInserted, lastLineToBeInserted+1, 1):
     if (peopleFound == True) :
         print(newPeople.toJSON())
 
-        indexPeople=0
-        for people in data:
-            if people["name"].lower() == newPeople.name.lower():
-                print("{newPeople.name} already in people.json, abort !")
-                exit(2)
-            else:
-                print('Adding '+newPeople.name)
-                data.insert(0, json.JSONDecoder(object_pairs_hook=OrderedDict).decode(newPeople.toJSON()))
-                os.rename("imageTemp.jpg", "../../people/images/"+newPeople.image)
-                ack_kubestronaut(row[12])
-                break
+        # Check for existing entry first; add only if not present
+        if any(p["name"].lower() == newPeople.name.lower() for p in data):
+            print(f"{newPeople.name} already in people.json, abort !")
+            exit(2)
+
+        print('Adding ' + newPeople.name)
+        data.insert(0, json.JSONDecoder(object_pairs_hook=OrderedDict).decode(newPeople.toJSON()))
+        os.rename("imageTemp.jpg", "../../people/images/" + newPeople.image)
+        ack_kubestronaut(row[12])
 
 sorted_people = sorted(data, key=lambda x: x['name'])
 
 with open('../../people/people.json', "w", encoding='utf-8') as jsonfile:
-    jsonfile.write(json.dumps(data, indent=4, ensure_ascii=False))
+    jsonfile.write(json.dumps(sorted_people, indent=4, ensure_ascii=False))
 
 if NON_acked_Kubestronauts:
     print("\n\nList of Kubestroauts that were NOT ACKED:")

--- a/Kubestronaut/Rendering/GenerateWorldTimelapseCartopy.py
+++ b/Kubestronaut/Rendering/GenerateWorldTimelapseCartopy.py
@@ -69,10 +69,13 @@ def update(frame):
     world['color'] = world['ADMIN'].apply(color_country)
     
     # Plot the countries with the specified color
-    world.plot(ax=ax, color=world['color'], edgecolor='black', transform=ccrs.Robinson(), alpha=0.8)
+    world.plot(ax=ax, color=world['color'], edgecolor='black', transform=ccrs.PlateCarree(), alpha=0.8)
 
-    # Add the OpenStreetMap basemap underneath the countries to give depth
-    cx.add_basemap(ax, crs=ccrs.Robinson().proj4_init, source=cx.providers.OpenStreetMap.Mapnik)
+    # Try to add a basemap for context; if unavailable, continue without it
+    try:
+        cx.add_basemap(ax, source=cx.providers.OpenStreetMap.Mapnik)
+    except Exception:
+        pass
 
     # Clear any previous text to avoid overlap and re-render fresh text
     fig.texts.clear()


### PR DESCRIPTION
This PR delivers a set of safe, focused improvements that increase stability and correctness without changing existing features:

- Fixes a compilation/runtime issue in utilities/labeler by making the changed_files argument optional, correcting an issueNum variable name, guarding access to argv[0] when matching against a configured list, and replacing a brittle integer parse helper with strconv.Atoi. These changes prevent crashes and improve CLI ergonomics while preserving behavior.
- Resolves duplicate/early-insert logic in Kubestronaut/CNCFInsertKubestronautInPeople_json.py so a new entry is only added if it does not already exist. The script now writes the sorted list back to people.json as intended.
- Ensures Ambassadors/CNCFInsertAmbassadorInPeople_json.py appends at the end when a new name sorts after all existing entries, preventing silent no-op behavior.
- Corrects the cartopy transform (PlateCarree for EPSG:4326 data) and guards the contextily basemap call to avoid runtime errors in Kubestronaut/Rendering/GenerateWorldTimelapseCartopy.py. Output remains the same except that failures to fetch/render a basemap will no longer crash the script.

Impact: Low-risk, focused fixes that improve stability and correctness. No functional features are added or removed.

## Compatibility

- No breaking changes. Existing workflows and scripts retain their intended behavior; failure modes are reduced.