### PR TITLE
feat(labeler): Add support for /assign and /unassign commands

### DIFF
--- a/utilities/labeler/labels.yaml
+++ b/utilities/labeler/labels.yaml
@@ -695,6 +695,20 @@ ruleset:
 # Misc Commands
 ##############################################################################
 
+- name: assign
+  kind: match
+  spec:
+    command: /assign
+  actions:
+  - kind: assign
+
+- name: unassign
+  kind: match
+  spec:
+    command: /unassign
+  actions:
+  - kind: unassign
+
 - name: help
   kind: match
   spec:


### PR DESCRIPTION
Description
This PR adds support for /assign and /unassign slash commands to the labeler tool, as requested in #109.

Changes Made
labeler.go:

Added AddAssignees and RemoveAssignees methods to GitHubClient interface
Implemented wrapper methods in GitHubClientWrapper
Added assign and unassign action kinds in executeAction function
Added assignUsers() and unassignUsers() functions with @ prefix handling
labels.yaml:

Added /assign command rule
Added /unassign command rule
labeler_test.go:

Updated mock client with assignee tracking
Added 4 test cases for assign/unassign functionality
Usage
/assign @username           # Assign single user
/assign @user1 @user2       # Assign multiple users
/assign username            # Works without @ prefix too
/unassign @username         # Unassign user
Testing
All 15 tests passing:

4 new tests for assign/unassign
11 existing tests still passing
go test -v .
PASS
ok      labeler
Closes #109