### PR TITLE
feat: landscape MCP server full expansion

### DIFF
--- a/utilities/landscape-mcp-server/.gitignore
+++ b/utilities/landscape-mcp-server/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts
+mcp-server

--- a/utilities/landscape-mcp-server/config.go
+++ b/utilities/landscape-mcp-server/config.go
@@ -1,0 +1,14 @@
+package main
+
+// LandscapeConfig holds configuration for the landscape being served.
+type LandscapeConfig struct {
+	Name        string // e.g. "CNCF"
+	Description string // e.g. "Cloud Native Computing Foundation"
+}
+
+func defaultConfig() LandscapeConfig {
+	return LandscapeConfig{
+		Name:        "CNCF",
+		Description: "Cloud Native Computing Foundation",
+	}
+}

--- a/utilities/landscape-mcp-server/config_test.go
+++ b/utilities/landscape-mcp-server/config_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := defaultConfig()
+	if cfg.Name != "CNCF" {
+		t.Errorf("expected Name=CNCF, got %s", cfg.Name)
+	}
+	if cfg.Description != "Cloud Native Computing Foundation" {
+		t.Errorf("expected Description='Cloud Native Computing Foundation', got %s", cfg.Description)
+	}
+}

--- a/utilities/landscape-mcp-server/dataset_loader.go
+++ b/utilities/landscape-mcp-server/dataset_loader.go
@@ -48,18 +48,107 @@ func loadDataset(ctx context.Context, src dataSource) (*Dataset, error) {
 		if err != nil {
 			log.Printf("warning: invalid joined_at for %s: %v", it.Name, err)
 		}
+		archived, err := parseDate(it.ArchivedAt)
+		if err != nil {
+			log.Printf("warning: invalid archived_at for %s: %v", it.Name, err)
+		}
+		latestAnnualReview, err := parseDate(it.LatestAnnualReviewAt)
+		if err != nil {
+			log.Printf("warning: invalid latest_annual_review_at for %s: %v", it.Name, err)
+		}
+
+		// Map audits
+		audits := make([]Audit, 0, len(it.Audits))
+		for _, a := range it.Audits {
+			auditDate, err := parseDate(a.Date)
+			if err != nil {
+				log.Printf("warning: invalid audit date for %s: %v", it.Name, err)
+				continue
+			}
+			audits = append(audits, Audit{
+				Date:   auditDate,
+				Type:   a.Type,
+				URL:    a.URL,
+				Vendor: a.Vendor,
+			})
+		}
+
+		// Map repositories
+		repos := make([]Repository, 0, len(it.Repositories))
+		for _, r := range it.Repositories {
+			repos = append(repos, Repository{
+				URL:     r.URL,
+				Primary: r.Primary,
+			})
+		}
+
+		// Map additional categories
+		addlCategories := make([]ItemCategory, 0, len(it.AdditionalCategories))
+		for _, ac := range it.AdditionalCategories {
+			addlCategories = append(addlCategories, ItemCategory{
+				Category:    ac.Category,
+				Subcategory: ac.Subcategory,
+			})
+		}
+
+		// Map summary
+		var summary *ItemSummary
+		if it.Summary != nil {
+			summary = &ItemSummary{
+				UseCase: it.Summary.UseCase,
+			}
+		}
 
 		item := LandscapeItem{
-			Name:              it.Name,
-			Category:          it.Category,
-			Subcategory:       it.Subcategory,
-			MemberSubcategory: strings.TrimSpace(it.MemberSubcategory),
-			Maturity:          strings.TrimSpace(it.Maturity),
-			JoinedAt:          joined,
-			AcceptedAt:        accepted,
-			GraduatedAt:       graduated,
-			IncubatingAt:      incubating,
-			CrunchbaseURL:     strings.TrimSpace(it.CrunchbaseURL),
+			// Identity
+			Name:        it.Name,
+			ID:          it.ID,
+			Description: it.Description,
+			HomepageURL: it.HomepageURL,
+			LogoURL:     it.Logo,
+
+			// Taxonomy
+			Category:             it.Category,
+			Subcategory:          it.Subcategory,
+			MemberSubcategory:    strings.TrimSpace(it.MemberSubcategory),
+			Maturity:             strings.TrimSpace(it.Maturity),
+			AdditionalCategories: addlCategories,
+
+			// Dates
+			JoinedAt:     joined,
+			AcceptedAt:   accepted,
+			GraduatedAt:  graduated,
+			IncubatingAt: incubating,
+			ArchivedAt:   archived,
+
+			// Project metadata
+			OSS:                   it.OSS,
+			Specification:         it.Specification,
+			EndUser:               it.EndUser,
+			ParentProject:         it.ParentProject,
+			LatestAnnualReviewAt:  latestAnnualReview,
+			LatestAnnualReviewURL: it.LatestAnnualReviewURL,
+			Summary:               summary,
+			Audits:                audits,
+
+			// Links
+			CrunchbaseURL:        strings.TrimSpace(it.CrunchbaseURL),
+			DevStatsURL:          it.DevStatsURL,
+			ArtworkURL:           it.ArtworkURL,
+			BlogURL:              it.BlogURL,
+			TwitterURL:           it.TwitterURL,
+			SlackURL:             it.SlackURL,
+			DiscordURL:           it.DiscordURL,
+			YouTubeURL:           it.YouTubeURL,
+			LinkedInURL:          it.LinkedInURL,
+			StackOverflowURL:     it.StackOverflowURL,
+			ChatChannel:          it.ChatChannel,
+			MailingListURL:       it.MailingListURL,
+			DocumentationURL:     it.DocumentationURL,
+			GithubDiscussionsURL: it.GithubDiscussionsURL,
+
+			// Repositories
+			Repositories: repos,
 		}
 		items = append(items, item)
 	}
@@ -86,7 +175,47 @@ func loadDataset(ctx context.Context, src dataSource) (*Dataset, error) {
 				Kind:        strings.TrimSpace(round.Kind),
 			})
 		}
-		orgs[url] = CrunchbaseOrganization{FundingRounds: rounds}
+
+		// Map acquisitions
+		acquisitions := make([]Acquisition, 0, len(org.Acquisitions))
+		for _, acq := range org.Acquisitions {
+			acqDate, err := parseDate(acq.AnnouncedOn)
+			if err != nil {
+				log.Printf("warning: invalid acquisition announced_on for %s: %v", url, err)
+				continue
+			}
+			acquisitions = append(acquisitions, Acquisition{
+				AcquireeName: acq.AcquireeName,
+				AnnouncedOn:  acqDate,
+			})
+		}
+
+		// Map total funding
+		var totalFunding *int64
+		if org.Funding != nil {
+			f := int64(math.Round(*org.Funding))
+			totalFunding = &f
+		}
+
+		orgs[url] = CrunchbaseOrganization{
+			Name:            org.Name,
+			Description:     org.Description,
+			HomepageURL:     org.HomepageURL,
+			City:            org.City,
+			Country:         org.Country,
+			Region:          org.Region,
+			CompanyType:     org.CompanyType,
+			NumEmployeesMin: org.NumEmployeesMin,
+			NumEmployeesMax: org.NumEmployeesMax,
+			Categories:      org.Categories,
+			TotalFunding:    totalFunding,
+			FundingRounds:   rounds,
+			Acquisitions:    acquisitions,
+			LinkedInURL:     org.LinkedInURL,
+			TwitterURL:      org.TwitterURL,
+			StockExchange:   org.StockExchange,
+			Ticker:          org.Ticker,
+		}
 	}
 
 	return &Dataset{
@@ -137,20 +266,90 @@ type fullDataset struct {
 }
 
 type fullItem struct {
-	Name              string `json:"name"`
-	Category          string `json:"category"`
-	Subcategory       string `json:"subcategory"`
-	MemberSubcategory string `json:"member_subcategory"`
-	Maturity          string `json:"maturity"`
-	JoinedAt          string `json:"joined_at"`
-	AcceptedAt        string `json:"accepted_at"`
-	GraduatedAt       string `json:"graduated_at"`
-	IncubatingAt      string `json:"incubating_at"`
-	CrunchbaseURL     string `json:"crunchbase_url"`
+	Name                  string             `json:"name"`
+	ID                    string             `json:"id"`
+	Description           string             `json:"description"`
+	HomepageURL           string             `json:"homepage_url"`
+	Logo                  string             `json:"logo"`
+	Category              string             `json:"category"`
+	Subcategory           string             `json:"subcategory"`
+	MemberSubcategory     string             `json:"member_subcategory"`
+	Maturity              string             `json:"maturity"`
+	AdditionalCategories  []fullItemCategory `json:"additional_categories"`
+	JoinedAt              string             `json:"joined_at"`
+	AcceptedAt            string             `json:"accepted_at"`
+	GraduatedAt           string             `json:"graduated_at"`
+	IncubatingAt          string             `json:"incubating_at"`
+	ArchivedAt            string             `json:"archived_at"`
+	OSS                   bool               `json:"oss"`
+	Specification         bool               `json:"specification"`
+	EndUser               bool               `json:"enduser"`
+	ParentProject         string             `json:"parent_project"`
+	LatestAnnualReviewAt  string             `json:"latest_annual_review_at"`
+	LatestAnnualReviewURL string             `json:"latest_annual_review_url"`
+	Summary               *fullItemSummary   `json:"summary"`
+	Audits                []fullAudit        `json:"audits"`
+	CrunchbaseURL         string             `json:"crunchbase_url"`
+	DevStatsURL           string             `json:"devstats_url"`
+	ArtworkURL            string             `json:"artwork_url"`
+	BlogURL               string             `json:"blog_url"`
+	TwitterURL            string             `json:"twitter_url"`
+	SlackURL              string             `json:"slack_url"`
+	DiscordURL            string             `json:"discord_url"`
+	YouTubeURL            string             `json:"youtube_url"`
+	LinkedInURL           string             `json:"linkedin_url"`
+	StackOverflowURL      string             `json:"stack_overflow_url"`
+	ChatChannel           string             `json:"chat_channel"`
+	MailingListURL        string             `json:"mailing_list_url"`
+	DocumentationURL      string             `json:"documentation_url"`
+	GithubDiscussionsURL  string             `json:"github_discussions_url"`
+	Repositories          []fullRepository   `json:"repositories"`
+}
+
+type fullItemCategory struct {
+	Category    string `json:"category"`
+	Subcategory string `json:"subcategory"`
+}
+
+type fullItemSummary struct {
+	UseCase string `json:"use_case"`
+}
+
+type fullAudit struct {
+	Date   string `json:"date"`
+	Type   string `json:"type"`
+	URL    string `json:"url"`
+	Vendor string `json:"vendor"`
+}
+
+type fullRepository struct {
+	URL     string `json:"url"`
+	Primary bool   `json:"primary"`
 }
 
 type fullOrganization struct {
-	FundingRounds []fullFundingRound `json:"funding_rounds"`
+	Name            string             `json:"name"`
+	Description     string             `json:"description"`
+	HomepageURL     string             `json:"homepage_url"`
+	City            string             `json:"city"`
+	Country         string             `json:"country"`
+	Region          string             `json:"region"`
+	CompanyType     string             `json:"company_type"`
+	NumEmployeesMin int                `json:"num_employees_min"`
+	NumEmployeesMax int                `json:"num_employees_max"`
+	Categories      []string           `json:"categories"`
+	Funding         *float64           `json:"funding"`
+	FundingRounds   []fullFundingRound `json:"funding_rounds"`
+	Acquisitions    []fullAcquisition  `json:"acquisitions"`
+	LinkedInURL     string             `json:"linkedin_url"`
+	TwitterURL      string             `json:"twitter_url"`
+	StockExchange   string             `json:"stock_exchange"`
+	Ticker          string             `json:"ticker"`
+}
+
+type fullAcquisition struct {
+	AcquireeName string `json:"acquiree_name"`
+	AnnouncedOn  string `json:"announced_on"`
 }
 
 type fullFundingRound struct {

--- a/utilities/landscape-mcp-server/dataset_loader.go
+++ b/utilities/landscape-mcp-server/dataset_loader.go
@@ -104,7 +104,8 @@ func readSource(ctx context.Context, filePath, url string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		resp, err := http.DefaultClient.Do(req)
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
 		}

--- a/utilities/landscape-mcp-server/dataset_loader_test.go
+++ b/utilities/landscape-mcp-server/dataset_loader_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+		wantErr bool
+		wantY   int
+		wantM   time.Month
+		wantD   int
+	}{
+		{
+			name:    "empty string returns nil",
+			input:   "",
+			wantNil: true,
+		},
+		{
+			name:    "whitespace-only returns nil",
+			input:   "  ",
+			wantNil: true,
+		},
+		{
+			name:  "valid date parses correctly",
+			input: "2024-06-15",
+			wantY: 2024,
+			wantM: time.June,
+			wantD: 15,
+		},
+		{
+			name:    "invalid string returns error",
+			input:   "not-a-date",
+			wantErr: true,
+		},
+		{
+			name:    "wrong format returns error",
+			input:   "06/15/2024",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDate(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("expected non-nil time, got nil")
+			}
+			if got.Year() != tt.wantY {
+				t.Errorf("year: got %d, want %d", got.Year(), tt.wantY)
+			}
+			if got.Month() != tt.wantM {
+				t.Errorf("month: got %v, want %v", got.Month(), tt.wantM)
+			}
+			if got.Day() != tt.wantD {
+				t.Errorf("day: got %d, want %d", got.Day(), tt.wantD)
+			}
+		})
+	}
+}

--- a/utilities/landscape-mcp-server/dataset_loader_test.go
+++ b/utilities/landscape-mcp-server/dataset_loader_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -78,5 +79,130 @@ func TestParseDate(t *testing.T) {
 				t.Errorf("day: got %d, want %d", got.Day(), tt.wantD)
 			}
 		})
+	}
+}
+
+func TestLoadExpandedFields(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	// Find and verify Kubernetes item
+	var k8s *LandscapeItem
+	for i := range ds.Items {
+		if ds.Items[i].Name == "Kubernetes" {
+			k8s = &ds.Items[i]
+			break
+		}
+	}
+	if k8s == nil {
+		t.Fatal("Kubernetes item not found")
+	}
+	if k8s.Description == "" {
+		t.Error("Kubernetes: expected non-empty Description")
+	}
+	if k8s.HomepageURL == "" {
+		t.Error("Kubernetes: expected non-empty HomepageURL")
+	}
+	if len(k8s.Repositories) == 0 {
+		t.Error("Kubernetes: expected at least one repository")
+	} else {
+		foundPrimary := false
+		for _, r := range k8s.Repositories {
+			if r.Primary {
+				foundPrimary = true
+				if !strings.Contains(r.URL, "kubernetes/kubernetes") {
+					t.Errorf("Kubernetes: expected primary repo URL to contain 'kubernetes/kubernetes', got %s", r.URL)
+				}
+			}
+		}
+		if !foundPrimary {
+			t.Error("Kubernetes: expected a primary repository")
+		}
+	}
+	if !k8s.OSS {
+		t.Error("Kubernetes: expected OSS to be true")
+	}
+	if k8s.DevStatsURL == "" {
+		t.Error("Kubernetes: expected non-empty DevStatsURL")
+	}
+	if k8s.BlogURL == "" {
+		t.Error("Kubernetes: expected non-empty BlogURL")
+	}
+	if k8s.TwitterURL == "" {
+		t.Error("Kubernetes: expected non-empty TwitterURL")
+	}
+	if k8s.SlackURL == "" {
+		t.Error("Kubernetes: expected non-empty SlackURL")
+	}
+	if k8s.ChatChannel == "" {
+		t.Error("Kubernetes: expected non-empty ChatChannel")
+	}
+
+	// Find and verify Akri item
+	var akri *LandscapeItem
+	for i := range ds.Items {
+		if ds.Items[i].Name == "Akri" {
+			akri = &ds.Items[i]
+			break
+		}
+	}
+	if akri == nil {
+		t.Fatal("Akri item not found")
+	}
+	if len(akri.Audits) == 0 {
+		t.Fatal("Akri: expected at least one audit")
+	}
+	if akri.Audits[0].Type != "security" {
+		t.Errorf("Akri: expected first audit type 'security', got %q", akri.Audits[0].Type)
+	}
+	if akri.Audits[0].Date == nil {
+		t.Error("Akri: expected first audit to have a date")
+	}
+	if akri.Audits[0].Vendor == "" {
+		t.Error("Akri: expected first audit to have a vendor")
+	}
+	if akri.Summary == nil {
+		t.Fatal("Akri: expected non-nil Summary")
+	}
+	if akri.Summary.UseCase == "" {
+		t.Error("Akri: expected non-empty Summary.UseCase")
+	}
+
+	// Find and verify TestGoldCorp Crunchbase org
+	org, ok := ds.CrunchbaseOrgs["https://www.crunchbase.com/organization/testgoldcorp"]
+	if !ok {
+		t.Fatal("TestGoldCorp crunchbase org not found")
+	}
+	if org.Name == "" {
+		t.Error("TestGoldCorp org: expected non-empty Name")
+	}
+	if org.City == "" {
+		t.Error("TestGoldCorp org: expected non-empty City")
+	}
+	if org.Country == "" {
+		t.Error("TestGoldCorp org: expected non-empty Country")
+	}
+	if org.NumEmployeesMin <= 0 {
+		t.Errorf("TestGoldCorp org: expected NumEmployeesMin > 0, got %d", org.NumEmployeesMin)
+	}
+	if len(org.Acquisitions) == 0 {
+		t.Fatal("TestGoldCorp org: expected at least one acquisition")
+	}
+	if org.Acquisitions[0].AcquireeName == "" {
+		t.Error("TestGoldCorp org: expected non-empty acquiree name")
+	}
+	if org.Acquisitions[0].AnnouncedOn == nil {
+		t.Error("TestGoldCorp org: expected acquisition to have an announced date")
+	}
+	if org.CompanyType != "for_profit" {
+		t.Errorf("TestGoldCorp org: expected CompanyType 'for_profit', got %q", org.CompanyType)
+	}
+	if len(org.Categories) == 0 {
+		t.Error("TestGoldCorp org: expected at least one category")
+	}
+	if org.LinkedInURL == "" {
+		t.Error("TestGoldCorp org: expected non-empty LinkedInURL")
+	}
+	if org.TwitterURL == "" {
+		t.Error("TestGoldCorp org: expected non-empty TwitterURL")
 	}
 }

--- a/utilities/landscape-mcp-server/main.go
+++ b/utilities/landscape-mcp-server/main.go
@@ -14,6 +14,10 @@ import (
 	"time"
 )
 
+// serverVersion is the semantic version of the MCP server, reported in the
+// initialize handshake.
+const serverVersion = "0.2.0"
+
 // JSON-RPC structures -------------------------------------------------------
 
 type jsonRPCRequest struct {
@@ -46,6 +50,7 @@ type serverState struct {
 	loadErr error
 	cfg     LandscapeConfig
 	tools   toolCatalogData
+	src     dataSource
 }
 
 var outputMu sync.Mutex
@@ -111,6 +116,18 @@ func buildToolCatalog(cfg LandscapeConfig) toolCatalogData {
 				Name:        "search_landscape",
 				Description: fmt.Sprintf("Full-text search across all %s landscape items by name, description, category, subcategory, or homepage URL.", cfg.Name),
 			},
+			"compare_projects": {
+				Name:        "compare_projects",
+				Description: fmt.Sprintf("Side-by-side comparison of two or more %s projects.", cfg.Name),
+			},
+			"funding_analysis": {
+				Name:        "funding_analysis",
+				Description: fmt.Sprintf("Analyze funding data from Crunchbase for %s landscape members.", cfg.Name),
+			},
+			"geographic_distribution": {
+				Name:        "geographic_distribution",
+				Description: fmt.Sprintf("Geographic breakdown of %s landscape members by Crunchbase location data.", cfg.Name),
+			},
 		},
 		advertisedTools: []string{
 			"query_projects",
@@ -120,6 +137,9 @@ func buildToolCatalog(cfg LandscapeConfig) toolCatalogData {
 			"list_categories",
 			"landscape_summary",
 			"search_landscape",
+			"compare_projects",
+			"funding_analysis",
+			"geographic_distribution",
 			"project_metrics",
 			"membership_metrics",
 		},
@@ -163,6 +183,25 @@ func (s *serverState) waitForDataset(ctx context.Context) (*Dataset, error) {
 	return s.dataset, nil
 }
 
+// refreshDataset reloads the dataset from the configured data source.
+// It replaces the in-memory dataset under a write lock so that in-flight
+// requests see a consistent snapshot.
+func refreshDataset(ctx context.Context, state *serverState) {
+	log.Println("dataset refresh requested")
+	go func() {
+		ds, err := loadDataset(ctx, state.src)
+		if err != nil {
+			log.Printf("dataset refresh failed: %v", err)
+			return
+		}
+		state.mu.Lock()
+		state.dataset = ds
+		state.loadErr = nil
+		state.mu.Unlock()
+		log.Printf("dataset refreshed (%d items)", len(ds.Items))
+	}()
+}
+
 // Main ----------------------------------------------------------------------
 
 func main() {
@@ -187,11 +226,14 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	src := dataSource{
+		filePath: *dataFile,
+		url:      *dataURL,
+	}
+	state.src = src
+
 	go func() {
-		ds, err := loadDataset(ctx, dataSource{
-			filePath: *dataFile,
-			url:      *dataURL,
-		})
+		ds, err := loadDataset(ctx, src)
 		state.setDataset(ds, err)
 		if err != nil {
 			log.Printf("error loading dataset: %v", err)
@@ -236,16 +278,21 @@ func handleRequest(ctx context.Context, req *jsonRPCRequest, state *serverState)
 			Result: mustJSON(map[string]interface{}{
 				"protocolVersion": "2024-11-05",
 				"capabilities": map[string]interface{}{
-					"tools": map[string]interface{}{},
+					"tools":     map[string]interface{}{},
+					"resources": map[string]interface{}{},
+					"prompts":   map[string]interface{}{},
 				},
 				"serverInfo": map[string]string{
 					"name":    fmt.Sprintf("%s-landscape-mcp-server", strings.ToLower(state.cfg.Name)),
-					"version": "0.2.0",
+					"version": serverVersion,
 				},
 			}),
 			ID: req.ID,
 		}
 	case "notifications/initialized":
+		return nil
+	case "notifications/dataset_refreshed":
+		refreshDataset(ctx, state)
 		return nil
 	case "tools/list":
 		tools := make([]map[string]interface{}, 0, len(state.tools.advertisedTools))
@@ -269,6 +316,14 @@ func handleRequest(ctx context.Context, req *jsonRPCRequest, state *serverState)
 		}
 	case "tools/call":
 		return handleToolsCall(ctx, req, state)
+	case "resources/list":
+		return handleResourcesList(req, state)
+	case "resources/read":
+		return handleResourcesRead(ctx, req, state)
+	case "prompts/list":
+		return handlePromptsList(req, state)
+	case "prompts/get":
+		return handlePromptsGet(req, state)
 	default:
 		return errorResponse(req.ID, -32601, "Method not found", nil)
 	}
@@ -309,6 +364,12 @@ func handleToolsCall(ctx context.Context, req *jsonRPCRequest, state *serverStat
 		return handleLandscapeSummary(req.ID, dataset)
 	case "search_landscape":
 		return handleSearchLandscape(req.ID, payload.Arguments, dataset)
+	case "compare_projects":
+		return handleCompareProjects(req.ID, payload.Arguments, dataset)
+	case "funding_analysis":
+		return handleFundingAnalysis(req.ID, payload.Arguments, dataset)
+	case "geographic_distribution":
+		return handleGeographicDistribution(req.ID, payload.Arguments, dataset)
 	default:
 		// Handle metric-based tools
 		var args struct {
@@ -407,6 +468,10 @@ func toolInputSchema(def toolDefinition) map[string]interface{} {
 				"type":        "integer",
 				"description": "Maximum number of results to return (default: 100)",
 			},
+			"offset": map[string]interface{}{
+				"type":        "integer",
+				"description": "Number of results to skip before returning (default: 0)",
+			},
 		}
 		return schema
 	case "query_members":
@@ -430,6 +495,10 @@ func toolInputSchema(def toolDefinition) map[string]interface{} {
 			"limit": map[string]interface{}{
 				"type":        "integer",
 				"description": "Maximum number of results to return (default: 100)",
+			},
+			"offset": map[string]interface{}{
+				"type":        "integer",
+				"description": "Number of results to skip before returning (default: 0)",
 			},
 		}
 		return schema
@@ -469,6 +538,38 @@ func toolInputSchema(def toolDefinition) map[string]interface{} {
 			},
 		}
 		schema["required"] = []string{"query"}
+		return schema
+	case "compare_projects":
+		schema["properties"] = map[string]interface{}{
+			"names": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Project names to compare (minimum 2)",
+				"minItems":    2,
+			},
+		}
+		schema["required"] = []string{"names"}
+		return schema
+	case "funding_analysis":
+		schema["properties"] = map[string]interface{}{
+			"tier": map[string]interface{}{
+				"type":        "string",
+				"description": "Filter by membership tier (e.g. Gold, Silver)",
+			},
+			"year": map[string]interface{}{
+				"type":        "integer",
+				"description": "Filter funding rounds to a specific year",
+			},
+		}
+		return schema
+	case "geographic_distribution":
+		schema["properties"] = map[string]interface{}{
+			"group_by": map[string]interface{}{
+				"type":        "string",
+				"description": "Group by: country (default), region, or city",
+				"enum":        []string{"country", "region", "city"},
+			},
+		}
 		return schema
 	}
 
@@ -553,6 +654,7 @@ func handleQueryProjects(id json.RawMessage, argsRaw json.RawMessage, ds *Datase
 		AcceptedFrom   string `json:"accepted_from"`
 		AcceptedTo     string `json:"accepted_to"`
 		Limit          int    `json:"limit"`
+		Offset         int    `json:"offset"`
 	}
 	if len(argsRaw) > 0 {
 		if err := json.Unmarshal(argsRaw, &args); err != nil {
@@ -575,6 +677,7 @@ func handleQueryProjects(id json.RawMessage, argsRaw json.RawMessage, ds *Datase
 		AcceptedFrom:   args.AcceptedFrom,
 		AcceptedTo:     args.AcceptedTo,
 		Limit:          args.Limit,
+		Offset:         args.Offset,
 	})
 	if err != nil {
 		return errorResponse(id, -32000, err.Error(), nil)
@@ -594,6 +697,7 @@ func handleQueryMembers(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset
 		JoinedFrom string `json:"joined_from"`
 		JoinedTo   string `json:"joined_to"`
 		Limit      int    `json:"limit"`
+		Offset     int    `json:"offset"`
 	}
 	if len(argsRaw) > 0 {
 		if err := json.Unmarshal(argsRaw, &args); err != nil {
@@ -610,6 +714,7 @@ func handleQueryMembers(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset
 		JoinedFrom: args.JoinedFrom,
 		JoinedTo:   args.JoinedTo,
 		Limit:      args.Limit,
+		Offset:     args.Offset,
 	})
 	if err != nil {
 		return errorResponse(id, -32000, err.Error(), nil)
@@ -721,5 +826,234 @@ func handleSearchLandscape(id json.RawMessage, argsRaw json.RawMessage, ds *Data
 		JSONRPC: "2.0",
 		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
 		ID:      id,
+	}
+}
+
+func handleCompareProjects(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset) *jsonRPCResponse {
+	var args struct {
+		Names []string `json:"names"`
+	}
+	if len(argsRaw) > 0 {
+		if err := json.Unmarshal(argsRaw, &args); err != nil {
+			return errorResponse(id, -32602, "Invalid arguments", nil)
+		}
+	}
+	if len(args.Names) < 2 {
+		return errorResponse(id, -32602, "at least 2 project names are required", nil)
+	}
+
+	result, err := compareProjects(ds, args.Names)
+	if err != nil {
+		return errorResponse(id, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
+		ID:      id,
+	}
+}
+
+func handleFundingAnalysis(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset) *jsonRPCResponse {
+	var args struct {
+		Tier string `json:"tier"`
+		Year int    `json:"year"`
+	}
+	if len(argsRaw) > 0 {
+		if err := json.Unmarshal(argsRaw, &args); err != nil {
+			return errorResponse(id, -32602, "Invalid arguments", nil)
+		}
+	}
+
+	result, err := fundingAnalysis(ds, args.Tier, args.Year)
+	if err != nil {
+		return errorResponse(id, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
+		ID:      id,
+	}
+}
+
+func handleGeographicDistribution(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset) *jsonRPCResponse {
+	var args struct {
+		GroupBy string `json:"group_by"`
+	}
+	if len(argsRaw) > 0 {
+		if err := json.Unmarshal(argsRaw, &args); err != nil {
+			return errorResponse(id, -32602, "Invalid arguments", nil)
+		}
+	}
+
+	result, err := geographicDistribution(ds, args.GroupBy)
+	if err != nil {
+		return errorResponse(id, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
+		ID:      id,
+	}
+}
+
+// MCP Resources handlers ----------------------------------------------------
+
+func handleResourcesList(req *jsonRPCRequest, state *serverState) *jsonRPCResponse {
+	resources := []map[string]string{
+		{
+			"uri":         "landscape://categories",
+			"name":        fmt.Sprintf("%s Categories", state.cfg.Name),
+			"description": "Complete category and subcategory tree with item counts",
+			"mimeType":    "application/json",
+		},
+		{
+			"uri":         "landscape://summary",
+			"name":        fmt.Sprintf("%s Summary", state.cfg.Name),
+			"description": "High-level landscape statistics and overview",
+			"mimeType":    "application/json",
+		},
+	}
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"resources": resources}),
+		ID:      req.ID,
+	}
+}
+
+func handleResourcesRead(ctx context.Context, req *jsonRPCRequest, state *serverState) *jsonRPCResponse {
+	var params struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, -32602, "Invalid params", nil)
+	}
+
+	dataset, err := state.waitForDataset(ctx)
+	if err != nil {
+		return errorResponse(req.ID, -32603, "Dataset unavailable", mustJSON(map[string]string{"error": err.Error()}))
+	}
+
+	var text string
+	switch params.URI {
+	case "landscape://categories":
+		text, err = listCategories(dataset)
+	case "landscape://summary":
+		text, err = landscapeSummary(dataset)
+	default:
+		return errorResponse(req.ID, -32602, fmt.Sprintf("Unknown resource URI: %s", params.URI), nil)
+	}
+
+	if err != nil {
+		return errorResponse(req.ID, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result: mustJSON(map[string]interface{}{
+			"contents": []map[string]string{
+				{
+					"uri":      params.URI,
+					"mimeType": "application/json",
+					"text":     text,
+				},
+			},
+		}),
+		ID: req.ID,
+	}
+}
+
+// MCP Prompts handlers ------------------------------------------------------
+
+func handlePromptsList(req *jsonRPCRequest, state *serverState) *jsonRPCResponse {
+	prompts := []map[string]interface{}{
+		{
+			"name":        "analyze_landscape",
+			"description": fmt.Sprintf("Analyze the current state of the %s landscape", state.cfg.Name),
+			"arguments":   []interface{}{},
+		},
+		{
+			"name":        "compare_projects",
+			"description": fmt.Sprintf("Compare specific projects in the %s landscape", state.cfg.Name),
+			"arguments": []map[string]interface{}{
+				{
+					"name":        "project_names",
+					"description": "Comma-separated list of project names to compare",
+					"required":    true,
+				},
+			},
+		},
+	}
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"prompts": prompts}),
+		ID:      req.ID,
+	}
+}
+
+func handlePromptsGet(req *jsonRPCRequest, state *serverState) *jsonRPCResponse {
+	var params struct {
+		Name      string            `json:"name"`
+		Arguments map[string]string `json:"arguments"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, -32602, "Invalid params", nil)
+	}
+
+	switch params.Name {
+	case "analyze_landscape":
+		return &jsonRPCResponse{
+			JSONRPC: "2.0",
+			Result: mustJSON(map[string]interface{}{
+				"description": fmt.Sprintf("Analyze the current state of the %s landscape", state.cfg.Name),
+				"messages": []map[string]interface{}{
+					{
+						"role": "user",
+						"content": map[string]string{
+							"type": "text",
+							"text": fmt.Sprintf(`Please analyze the current state of the %s landscape. Use the available tools to:
+1. Get a landscape summary using the landscape_summary tool
+2. List all categories using the list_categories tool
+3. Identify trends in project maturity levels
+4. Analyze membership distribution across tiers
+5. Provide insights and recommendations based on the data`, state.cfg.Name),
+						},
+					},
+				},
+			}),
+			ID: req.ID,
+		}
+	case "compare_projects":
+		projectNames := params.Arguments["project_names"]
+		if projectNames == "" {
+			return errorResponse(req.ID, -32602, "Missing required argument: project_names", nil)
+		}
+		return &jsonRPCResponse{
+			JSONRPC: "2.0",
+			Result: mustJSON(map[string]interface{}{
+				"description": fmt.Sprintf("Compare specific projects in the %s landscape", state.cfg.Name),
+				"messages": []map[string]interface{}{
+					{
+						"role": "user",
+						"content": map[string]string{
+							"type": "text",
+							"text": fmt.Sprintf(`Please compare the following %s projects: %s
+
+Use the compare_projects tool to get detailed information, then analyze:
+1. Maturity levels and timeline to graduation
+2. Repository activity and community health
+3. Organizational backing and funding
+4. Key similarities and differences
+5. Recommendations for each project's growth path`, state.cfg.Name, projectNames),
+						},
+					},
+				},
+			}),
+			ID: req.ID,
+		}
+	default:
+		return errorResponse(req.ID, -32602, fmt.Sprintf("Unknown prompt: %s", params.Name), nil)
 	}
 }

--- a/utilities/landscape-mcp-server/main.go
+++ b/utilities/landscape-mcp-server/main.go
@@ -343,6 +343,14 @@ func toolInputSchema(def toolDefinition) map[string]interface{} {
 				"type":        "string",
 				"description": "Filter by project name (case-insensitive substring match)",
 			},
+			"category": map[string]interface{}{
+				"type":        "string",
+				"description": "Filter by category (e.g., Provisioning, Runtime, Observability and Analysis)",
+			},
+			"subcategory": map[string]interface{}{
+				"type":        "string",
+				"description": "Filter by subcategory (e.g., Container Runtime, Service Mesh)",
+			},
 			"graduated_from": map[string]interface{}{
 				"type":        "string",
 				"description": "Filter projects graduated on or after this date (YYYY-MM-DD)",
@@ -476,6 +484,8 @@ func handleQueryProjects(id json.RawMessage, argsRaw json.RawMessage, ds *Datase
 	var args struct {
 		Maturity       string `json:"maturity"`
 		Name           string `json:"name"`
+		Category       string `json:"category"`
+		Subcategory    string `json:"subcategory"`
 		GraduatedFrom  string `json:"graduated_from"`
 		GraduatedTo    string `json:"graduated_to"`
 		IncubatingFrom string `json:"incubating_from"`
@@ -496,6 +506,8 @@ func handleQueryProjects(id json.RawMessage, argsRaw json.RawMessage, ds *Datase
 	result, err := queryProjects(ds, ProjectQuery{
 		Maturity:       args.Maturity,
 		Name:           args.Name,
+		Category:       args.Category,
+		Subcategory:    args.Subcategory,
 		GraduatedFrom:  args.GraduatedFrom,
 		GraduatedTo:    args.GraduatedTo,
 		IncubatingFrom: args.IncubatingFrom,

--- a/utilities/landscape-mcp-server/main.go
+++ b/utilities/landscape-mcp-server/main.go
@@ -480,11 +480,21 @@ func handleQueryProjects(id json.RawMessage, argsRaw json.RawMessage, ds *Datase
 			return errorResponse(id, -32602, "Invalid arguments", nil)
 		}
 	}
-	if args.Limit == 0 {
+	if args.Limit <= 0 || args.Limit > 500 {
 		args.Limit = 100
 	}
 
-	result, err := queryProjects(ds, args.Maturity, args.Name, args.GraduatedFrom, args.GraduatedTo, args.IncubatingFrom, args.IncubatingTo, args.AcceptedFrom, args.AcceptedTo, args.Limit)
+	result, err := queryProjects(ds, ProjectQuery{
+		Maturity:       args.Maturity,
+		Name:           args.Name,
+		GraduatedFrom:  args.GraduatedFrom,
+		GraduatedTo:    args.GraduatedTo,
+		IncubatingFrom: args.IncubatingFrom,
+		IncubatingTo:   args.IncubatingTo,
+		AcceptedFrom:   args.AcceptedFrom,
+		AcceptedTo:     args.AcceptedTo,
+		Limit:          args.Limit,
+	})
 	if err != nil {
 		return errorResponse(id, -32000, err.Error(), nil)
 	}
@@ -508,11 +518,16 @@ func handleQueryMembers(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset
 			return errorResponse(id, -32602, "Invalid arguments", nil)
 		}
 	}
-	if args.Limit == 0 {
+	if args.Limit <= 0 || args.Limit > 500 {
 		args.Limit = 100
 	}
 
-	result, err := queryMembers(ds, args.Tier, args.JoinedFrom, args.JoinedTo, args.Limit)
+	result, err := queryMembers(ds, MemberQuery{
+		Tier:       args.Tier,
+		JoinedFrom: args.JoinedFrom,
+		JoinedTo:   args.JoinedTo,
+		Limit:      args.Limit,
+	})
 	if err != nil {
 		return errorResponse(id, -32000, err.Error(), nil)
 	}

--- a/utilities/landscape-mcp-server/main.go
+++ b/utilities/landscape-mcp-server/main.go
@@ -87,20 +87,6 @@ var (
 			Name:        "get_project_details",
 			Description: "Get detailed information about a specific CNCF project by name.",
 		},
-		// Legacy aggregated tool retained for compatibility with earlier clients.
-		"query_landscape": {
-			Name:        "query_landscape",
-			Description: "Run predefined analytical queries over the CNCF landscape dataset.",
-			Metrics: []string{
-				"incubating_project_count",
-				"sandbox_projects_joined_this_year",
-				"projects_graduated_last_year",
-				"gold_members_joined_this_year",
-				"silver_members_joined_this_year",
-				"silver_members_raised_last_month",
-				"gold_members_raised_this_year",
-			},
-		},
 	}
 	advertisedTools = []string{
 		"query_projects",

--- a/utilities/landscape-mcp-server/main.go
+++ b/utilities/landscape-mcp-server/main.go
@@ -44,6 +44,8 @@ type serverState struct {
 	mu      sync.RWMutex
 	dataset *Dataset
 	loadErr error
+	cfg     LandscapeConfig
+	tools   toolCatalogData
 }
 
 var outputMu sync.Mutex
@@ -54,51 +56,62 @@ type toolDefinition struct {
 	Metrics     []string
 }
 
-var (
-	toolCatalog = map[string]toolDefinition{
-		"project_metrics": {
-			Name:        "project_metrics",
-			Description: "Answer questions about CNCF project counts and progress.",
-			Metrics: []string{
-				"incubating_project_count",
-				"sandbox_projects_joined_this_year",
-				"projects_graduated_last_year",
-			},
-		},
-		"membership_metrics": {
-			Name:        "membership_metrics",
-			Description: "Answer questions about CNCF membership activity and funding.",
-			Metrics: []string{
-				"gold_members_joined_this_year",
-				"silver_members_joined_this_year",
-				"silver_members_raised_last_month",
-				"gold_members_raised_this_year",
-			},
-		},
-		"query_projects": {
-			Name:        "query_projects",
-			Description: "Query CNCF projects with flexible filtering by maturity, dates, and name. Returns detailed project information.",
-		},
-		"query_members": {
-			Name:        "query_members",
-			Description: "Query CNCF members with flexible filtering by membership tier and join dates.",
-		},
-		"get_project_details": {
-			Name:        "get_project_details",
-			Description: "Get detailed information about a specific CNCF project by name.",
-		},
-	}
-	advertisedTools = []string{
-		"query_projects",
-		"query_members",
-		"get_project_details",
-		"project_metrics",
-		"membership_metrics",
-	}
-)
+type toolCatalogData struct {
+	catalog         map[string]toolDefinition
+	advertisedTools []string
+}
 
-func newServerState() *serverState {
-	return &serverState{ready: make(chan struct{})}
+func buildToolCatalog(cfg LandscapeConfig) toolCatalogData {
+	return toolCatalogData{
+		catalog: map[string]toolDefinition{
+			"project_metrics": {
+				Name:        "project_metrics",
+				Description: fmt.Sprintf("Answer questions about %s project counts and progress.", cfg.Name),
+				Metrics: []string{
+					"incubating_project_count",
+					"sandbox_projects_joined_this_year",
+					"projects_graduated_last_year",
+				},
+			},
+			"membership_metrics": {
+				Name:        "membership_metrics",
+				Description: fmt.Sprintf("Answer questions about %s membership activity and funding.", cfg.Name),
+				Metrics: []string{
+					"gold_members_joined_this_year",
+					"silver_members_joined_this_year",
+					"silver_members_raised_last_month",
+					"gold_members_raised_this_year",
+				},
+			},
+			"query_projects": {
+				Name:        "query_projects",
+				Description: fmt.Sprintf("Query %s projects with flexible filtering by maturity, dates, and name. Returns detailed project information.", cfg.Name),
+			},
+			"query_members": {
+				Name:        "query_members",
+				Description: fmt.Sprintf("Query %s members with flexible filtering by membership tier and join dates.", cfg.Name),
+			},
+			"get_project_details": {
+				Name:        "get_project_details",
+				Description: fmt.Sprintf("Get detailed information about a specific %s project by name.", cfg.Name),
+			},
+		},
+		advertisedTools: []string{
+			"query_projects",
+			"query_members",
+			"get_project_details",
+			"project_metrics",
+			"membership_metrics",
+		},
+	}
+}
+
+func newServerState(cfg LandscapeConfig) *serverState {
+	return &serverState{
+		ready: make(chan struct{}),
+		cfg:   cfg,
+		tools: buildToolCatalog(cfg),
+	}
 }
 
 func (s *serverState) setDataset(ds *Dataset, err error) {
@@ -135,12 +148,22 @@ func (s *serverState) waitForDataset(ctx context.Context) (*Dataset, error) {
 func main() {
 	dataFile := flag.String("data-file", "", "Path to the landscape full dataset JSON file")
 	dataURL := flag.String("data-url", "https://landscape.cncf.io/data/full.json", "URL to the landscape full dataset JSON file")
+	landscapeName := flag.String("landscape-name", "", "Name of the landscape (e.g. CNCF)")
+	landscapeDesc := flag.String("landscape-description", "", "Description of the landscape")
 	flag.Parse()
+
+	cfg := defaultConfig()
+	if *landscapeName != "" {
+		cfg.Name = *landscapeName
+	}
+	if *landscapeDesc != "" {
+		cfg.Description = *landscapeDesc
+	}
 
 	log.SetOutput(os.Stderr)
 	log.SetFlags(0)
 
-	state := newServerState()
+	state := newServerState(cfg)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -196,8 +219,8 @@ func handleRequest(ctx context.Context, req *jsonRPCRequest, state *serverState)
 					"tools": map[string]interface{}{},
 				},
 				"serverInfo": map[string]string{
-					"name":    "landscape2-mcp-server-go",
-					"version": "0.1.0",
+					"name":    fmt.Sprintf("%s-landscape-mcp-server", strings.ToLower(state.cfg.Name)),
+					"version": "0.2.0",
 				},
 			}),
 			ID: req.ID,
@@ -205,9 +228,9 @@ func handleRequest(ctx context.Context, req *jsonRPCRequest, state *serverState)
 	case "notifications/initialized":
 		return nil
 	case "tools/list":
-		tools := make([]map[string]interface{}, 0, len(advertisedTools))
-		for _, name := range advertisedTools {
-			def, ok := toolCatalog[name]
+		tools := make([]map[string]interface{}, 0, len(state.tools.advertisedTools))
+		for _, name := range state.tools.advertisedTools {
+			def, ok := state.tools.catalog[name]
 			if !ok {
 				continue
 			}
@@ -240,7 +263,7 @@ func handleToolsCall(ctx context.Context, req *jsonRPCRequest, state *serverStat
 		return errorResponse(req.ID, -32602, "Invalid params", nil)
 	}
 
-	def, ok := toolCatalog[payload.Name]
+	def, ok := state.tools.catalog[payload.Name]
 	if !ok {
 		return errorResponse(req.ID, -32601, "Tool not found", nil)
 	}

--- a/utilities/landscape-mcp-server/main.go
+++ b/utilities/landscape-mcp-server/main.go
@@ -95,11 +95,31 @@ func buildToolCatalog(cfg LandscapeConfig) toolCatalogData {
 				Name:        "get_project_details",
 				Description: fmt.Sprintf("Get detailed information about a specific %s project by name.", cfg.Name),
 			},
+			"get_member_details": {
+				Name:        "get_member_details",
+				Description: fmt.Sprintf("Get detailed information about a specific %s member by name.", cfg.Name),
+			},
+			"list_categories": {
+				Name:        "list_categories",
+				Description: fmt.Sprintf("List all categories and subcategories in the %s landscape with item counts.", cfg.Name),
+			},
+			"landscape_summary": {
+				Name:        "landscape_summary",
+				Description: fmt.Sprintf("Get a high-level statistical overview of the entire %s landscape.", cfg.Name),
+			},
+			"search_landscape": {
+				Name:        "search_landscape",
+				Description: fmt.Sprintf("Full-text search across all %s landscape items by name, description, category, subcategory, or homepage URL.", cfg.Name),
+			},
 		},
 		advertisedTools: []string{
 			"query_projects",
 			"query_members",
 			"get_project_details",
+			"get_member_details",
+			"list_categories",
+			"landscape_summary",
+			"search_landscape",
 			"project_metrics",
 			"membership_metrics",
 		},
@@ -281,6 +301,14 @@ func handleToolsCall(ctx context.Context, req *jsonRPCRequest, state *serverStat
 		return handleQueryMembers(req.ID, payload.Arguments, dataset)
 	case "get_project_details":
 		return handleGetProjectDetails(req.ID, payload.Arguments, dataset)
+	case "get_member_details":
+		return handleGetMemberDetails(req.ID, payload.Arguments, dataset)
+	case "list_categories":
+		return handleListCategories(req.ID, dataset)
+	case "landscape_summary":
+		return handleLandscapeSummary(req.ID, dataset)
+	case "search_landscape":
+		return handleSearchLandscape(req.ID, payload.Arguments, dataset)
 	default:
 		// Handle metric-based tools
 		var args struct {
@@ -413,6 +441,34 @@ func toolInputSchema(def toolDefinition) map[string]interface{} {
 			},
 		}
 		schema["required"] = []string{"name"}
+		return schema
+	case "get_member_details":
+		schema["properties"] = map[string]interface{}{
+			"name": map[string]interface{}{
+				"type":        "string",
+				"description": "Member name to search for (case-insensitive)",
+			},
+		}
+		schema["required"] = []string{"name"}
+		return schema
+	case "list_categories":
+		// No additional properties needed
+		return schema
+	case "landscape_summary":
+		// No additional properties needed
+		return schema
+	case "search_landscape":
+		schema["properties"] = map[string]interface{}{
+			"query": map[string]interface{}{
+				"type":        "string",
+				"description": "Search term (case-insensitive substring match)",
+			},
+			"limit": map[string]interface{}{
+				"type":        "integer",
+				"description": "Maximum results (default 20, max 100)",
+			},
+		}
+		schema["required"] = []string{"query"}
 		return schema
 	}
 
@@ -580,6 +636,83 @@ func handleGetProjectDetails(id json.RawMessage, argsRaw json.RawMessage, ds *Da
 	}
 
 	result, err := getProjectDetails(ds, args.Name)
+	if err != nil {
+		return errorResponse(id, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
+		ID:      id,
+	}
+}
+
+func handleGetMemberDetails(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset) *jsonRPCResponse {
+	var args struct {
+		Name string `json:"name"`
+	}
+	if len(argsRaw) > 0 {
+		if err := json.Unmarshal(argsRaw, &args); err != nil {
+			return errorResponse(id, -32602, "Invalid arguments", nil)
+		}
+	}
+	if args.Name == "" {
+		return errorResponse(id, -32602, "name parameter is required", nil)
+	}
+
+	result, err := getMemberDetails(ds, args.Name)
+	if err != nil {
+		return errorResponse(id, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
+		ID:      id,
+	}
+}
+
+func handleListCategories(id json.RawMessage, ds *Dataset) *jsonRPCResponse {
+	result, err := listCategories(ds)
+	if err != nil {
+		return errorResponse(id, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
+		ID:      id,
+	}
+}
+
+func handleLandscapeSummary(id json.RawMessage, ds *Dataset) *jsonRPCResponse {
+	result, err := landscapeSummary(ds)
+	if err != nil {
+		return errorResponse(id, -32000, err.Error(), nil)
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  mustJSON(map[string]interface{}{"content": []map[string]string{{"type": "text", "text": result}}}),
+		ID:      id,
+	}
+}
+
+func handleSearchLandscape(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset) *jsonRPCResponse {
+	var args struct {
+		Query string `json:"query"`
+		Limit int    `json:"limit"`
+	}
+	if len(argsRaw) > 0 {
+		if err := json.Unmarshal(argsRaw, &args); err != nil {
+			return errorResponse(id, -32602, "Invalid arguments", nil)
+		}
+	}
+	if args.Query == "" {
+		return errorResponse(id, -32602, "query parameter is required", nil)
+	}
+
+	result, err := searchLandscape(ds, args.Query, args.Limit)
 	if err != nil {
 		return errorResponse(id, -32000, err.Error(), nil)
 	}

--- a/utilities/landscape-mcp-server/main.go
+++ b/utilities/landscape-mcp-server/main.go
@@ -387,6 +387,10 @@ func toolInputSchema(def toolDefinition) map[string]interface{} {
 				"type":        "string",
 				"description": "Filter by membership tier (e.g., Gold, Silver, Platinum, End User Supporter)",
 			},
+			"category": map[string]interface{}{
+				"type":        "string",
+				"description": "Filter by category (e.g., CNCF Members)",
+			},
 			"joined_from": map[string]interface{}{
 				"type":        "string",
 				"description": "Filter members joined on or after this date (YYYY-MM-DD)",
@@ -530,6 +534,7 @@ func handleQueryProjects(id json.RawMessage, argsRaw json.RawMessage, ds *Datase
 func handleQueryMembers(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset) *jsonRPCResponse {
 	var args struct {
 		Tier       string `json:"tier"`
+		Category   string `json:"category"`
 		JoinedFrom string `json:"joined_from"`
 		JoinedTo   string `json:"joined_to"`
 		Limit      int    `json:"limit"`
@@ -545,6 +550,7 @@ func handleQueryMembers(id json.RawMessage, argsRaw json.RawMessage, ds *Dataset
 
 	result, err := queryMembers(ds, MemberQuery{
 		Tier:       args.Tier,
+		Category:   args.Category,
 		JoinedFrom: args.JoinedFrom,
 		JoinedTo:   args.JoinedTo,
 		Limit:      args.Limit,

--- a/utilities/landscape-mcp-server/metrics.go
+++ b/utilities/landscape-mcp-server/metrics.go
@@ -19,6 +19,51 @@ type projectResult struct {
 	JoinedAt     string `json:"joined_at,omitempty"`
 }
 
+type orgSummary struct {
+	Name            string   `json:"name,omitempty"`
+	Description     string   `json:"description,omitempty"`
+	City            string   `json:"city,omitempty"`
+	Country         string   `json:"country,omitempty"`
+	Region          string   `json:"region,omitempty"`
+	CompanyType     string   `json:"company_type,omitempty"`
+	NumEmployeesMin int      `json:"num_employees_min,omitempty"`
+	NumEmployeesMax int      `json:"num_employees_max,omitempty"`
+	Categories      []string `json:"categories,omitempty"`
+	TotalFunding    *int64   `json:"total_funding_usd,omitempty"`
+	StockExchange   string   `json:"stock_exchange,omitempty"`
+	Ticker          string   `json:"ticker,omitempty"`
+}
+
+type auditResult struct {
+	Date   string `json:"date,omitempty"`
+	Type   string `json:"type"`
+	URL    string `json:"url"`
+	Vendor string `json:"vendor"`
+}
+
+type projectDetailResult struct {
+	Name                  string            `json:"name"`
+	Category              string            `json:"category"`
+	Subcategory           string            `json:"subcategory"`
+	Maturity              string            `json:"maturity,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	AcceptedAt            string            `json:"accepted_at,omitempty"`
+	IncubatingAt          string            `json:"incubating_at,omitempty"`
+	GraduatedAt           string            `json:"graduated_at,omitempty"`
+	ArchivedAt            string            `json:"archived_at,omitempty"`
+	JoinedAt              string            `json:"joined_at,omitempty"`
+	HomepageURL           string            `json:"homepage_url,omitempty"`
+	OSS                   bool              `json:"oss"`
+	Summary               *ItemSummary      `json:"summary,omitempty"`
+	Repositories          []Repository      `json:"repositories,omitempty"`
+	Audits                []auditResult     `json:"audits,omitempty"`
+	LatestAnnualReviewAt  string            `json:"latest_annual_review_at,omitempty"`
+	LatestAnnualReviewURL string            `json:"latest_annual_review_url,omitempty"`
+	AdditionalCategories  []ItemCategory    `json:"additional_categories,omitempty"`
+	Links                 map[string]string `json:"links,omitempty"`
+	Organization          *orgSummary       `json:"organization,omitempty"`
+}
+
 type memberResult struct {
 	Name              string `json:"name"`
 	Category          string `json:"category"`
@@ -452,10 +497,76 @@ func queryMembers(ds *Dataset, q MemberQuery) (string, error) {
 	return string(data), nil
 }
 
+// buildLinks constructs a map of non-empty link URLs from a LandscapeItem.
+func buildLinks(item LandscapeItem) map[string]string {
+	links := make(map[string]string)
+	if item.DevStatsURL != "" {
+		links["devstats"] = item.DevStatsURL
+	}
+	if item.BlogURL != "" {
+		links["blog"] = item.BlogURL
+	}
+	if item.TwitterURL != "" {
+		links["twitter"] = item.TwitterURL
+	}
+	if item.SlackURL != "" {
+		links["slack"] = item.SlackURL
+	}
+	if item.DiscordURL != "" {
+		links["discord"] = item.DiscordURL
+	}
+	if item.YouTubeURL != "" {
+		links["youtube"] = item.YouTubeURL
+	}
+	if item.LinkedInURL != "" {
+		links["linkedin"] = item.LinkedInURL
+	}
+	if item.StackOverflowURL != "" {
+		links["stackoverflow"] = item.StackOverflowURL
+	}
+	if item.ChatChannel != "" {
+		links["chat_channel"] = item.ChatChannel
+	}
+	if item.MailingListURL != "" {
+		links["mailing_list"] = item.MailingListURL
+	}
+	if item.DocumentationURL != "" {
+		links["documentation"] = item.DocumentationURL
+	}
+	if item.GithubDiscussionsURL != "" {
+		links["github_discussions"] = item.GithubDiscussionsURL
+	}
+	if item.ArtworkURL != "" {
+		links["artwork"] = item.ArtworkURL
+	}
+	if len(links) == 0 {
+		return nil
+	}
+	return links
+}
+
+// buildOrgSummary creates an orgSummary from a CrunchbaseOrganization.
+func buildOrgSummary(org CrunchbaseOrganization) *orgSummary {
+	return &orgSummary{
+		Name:            org.Name,
+		Description:     org.Description,
+		City:            org.City,
+		Country:         org.Country,
+		Region:          org.Region,
+		CompanyType:     org.CompanyType,
+		NumEmployeesMin: org.NumEmployeesMin,
+		NumEmployeesMax: org.NumEmployeesMax,
+		Categories:      org.Categories,
+		TotalFunding:    org.TotalFunding,
+		StockExchange:   org.StockExchange,
+		Ticker:          org.Ticker,
+	}
+}
+
 // getProjectDetails returns detailed information about a specific project
 func getProjectDetails(ds *Dataset, name string) (string, error) {
 	nameLower := strings.ToLower(name)
-	var matches []projectResult
+	var matches []projectDetailResult
 
 	for _, item := range ds.Items {
 		// Only include projects (items with maturity)
@@ -464,11 +575,15 @@ func getProjectDetails(ds *Dataset, name string) (string, error) {
 		}
 
 		if strings.Contains(strings.ToLower(item.Name), nameLower) {
-			detail := projectResult{
+			detail := projectDetailResult{
 				Name:        item.Name,
 				Category:    item.Category,
 				Subcategory: item.Subcategory,
 				Maturity:    item.Maturity,
+				Description: item.Description,
+				HomepageURL: item.HomepageURL,
+				OSS:         item.OSS,
+				Summary:     item.Summary,
 			}
 			if item.AcceptedAt != nil {
 				detail.AcceptedAt = item.AcceptedAt.Format("2006-01-02")
@@ -479,9 +594,52 @@ func getProjectDetails(ds *Dataset, name string) (string, error) {
 			if item.GraduatedAt != nil {
 				detail.GraduatedAt = item.GraduatedAt.Format("2006-01-02")
 			}
+			if item.ArchivedAt != nil {
+				detail.ArchivedAt = item.ArchivedAt.Format("2006-01-02")
+			}
 			if item.JoinedAt != nil {
 				detail.JoinedAt = item.JoinedAt.Format("2006-01-02")
 			}
+			if item.LatestAnnualReviewAt != nil {
+				detail.LatestAnnualReviewAt = item.LatestAnnualReviewAt.Format("2006-01-02")
+			}
+			detail.LatestAnnualReviewURL = item.LatestAnnualReviewURL
+
+			if len(item.Repositories) > 0 {
+				detail.Repositories = item.Repositories
+			}
+
+			// Map audits
+			if len(item.Audits) > 0 {
+				audits := make([]auditResult, 0, len(item.Audits))
+				for _, a := range item.Audits {
+					ar := auditResult{
+						Type:   a.Type,
+						URL:    a.URL,
+						Vendor: a.Vendor,
+					}
+					if a.Date != nil {
+						ar.Date = a.Date.Format("2006-01-02")
+					}
+					audits = append(audits, ar)
+				}
+				detail.Audits = audits
+			}
+
+			if len(item.AdditionalCategories) > 0 {
+				detail.AdditionalCategories = item.AdditionalCategories
+			}
+
+			// Build links
+			detail.Links = buildLinks(item)
+
+			// Look up Crunchbase org
+			if item.CrunchbaseURL != "" {
+				if org, ok := ds.CrunchbaseOrgs[item.CrunchbaseURL]; ok {
+					detail.Organization = buildOrgSummary(org)
+				}
+			}
+
 			matches = append(matches, detail)
 		}
 	}

--- a/utilities/landscape-mcp-server/metrics.go
+++ b/utilities/landscape-mcp-server/metrics.go
@@ -8,6 +8,25 @@ import (
 	"time"
 )
 
+type projectResult struct {
+	Name         string `json:"name"`
+	Category     string `json:"category"`
+	Subcategory  string `json:"subcategory"`
+	Maturity     string `json:"maturity,omitempty"`
+	AcceptedAt   string `json:"accepted_at,omitempty"`
+	IncubatingAt string `json:"incubating_at,omitempty"`
+	GraduatedAt  string `json:"graduated_at,omitempty"`
+	JoinedAt     string `json:"joined_at,omitempty"`
+}
+
+type memberResult struct {
+	Name              string `json:"name"`
+	Category          string `json:"category"`
+	Subcategory       string `json:"subcategory"`
+	MemberSubcategory string `json:"member_subcategory,omitempty"`
+	JoinedAt          string `json:"joined_at,omitempty"`
+}
+
 func executeMetric(metric string, ds *Dataset, now time.Time) (string, error) {
 	switch metric {
 	case "incubating_project_count":
@@ -199,59 +218,61 @@ func membersJoinedByTier(ds *Dataset, tier string, year int) []string {
 	return members
 }
 
-// queryProjects filters and returns projects based on various criteria
-func queryProjects(ds *Dataset, maturity, name, graduatedFrom, graduatedTo, incubatingFrom, incubatingTo, acceptedFrom, acceptedTo string, limit int) (string, error) {
-	type projectResult struct {
-		Name         string `json:"name"`
-		Category     string `json:"category"`
-		Subcategory  string `json:"subcategory"`
-		Maturity     string `json:"maturity,omitempty"`
-		AcceptedAt   string `json:"accepted_at,omitempty"`
-		IncubatingAt string `json:"incubating_at,omitempty"`
-		GraduatedAt  string `json:"graduated_at,omitempty"`
-		JoinedAt     string `json:"joined_at,omitempty"`
-	}
+// ProjectQuery holds the parameters for querying projects.
+type ProjectQuery struct {
+	Maturity       string
+	Name           string
+	GraduatedFrom  string
+	GraduatedTo    string
+	IncubatingFrom string
+	IncubatingTo   string
+	AcceptedFrom   string
+	AcceptedTo     string
+	Limit          int
+}
 
+// queryProjects filters and returns projects based on various criteria
+func queryProjects(ds *Dataset, q ProjectQuery) (string, error) {
 	// Parse date filters
 	var gradFromDate, gradToDate, incFromDate, incToDate, accFromDate, accToDate *time.Time
 
-	if graduatedFrom != "" {
-		d, err := time.Parse("2006-01-02", graduatedFrom)
+	if q.GraduatedFrom != "" {
+		d, err := time.Parse("2006-01-02", q.GraduatedFrom)
 		if err != nil {
 			return "", fmt.Errorf("invalid graduated_from date: %w", err)
 		}
 		gradFromDate = &d
 	}
-	if graduatedTo != "" {
-		d, err := time.Parse("2006-01-02", graduatedTo)
+	if q.GraduatedTo != "" {
+		d, err := time.Parse("2006-01-02", q.GraduatedTo)
 		if err != nil {
 			return "", fmt.Errorf("invalid graduated_to date: %w", err)
 		}
 		gradToDate = &d
 	}
-	if incubatingFrom != "" {
-		d, err := time.Parse("2006-01-02", incubatingFrom)
+	if q.IncubatingFrom != "" {
+		d, err := time.Parse("2006-01-02", q.IncubatingFrom)
 		if err != nil {
 			return "", fmt.Errorf("invalid incubating_from date: %w", err)
 		}
 		incFromDate = &d
 	}
-	if incubatingTo != "" {
-		d, err := time.Parse("2006-01-02", incubatingTo)
+	if q.IncubatingTo != "" {
+		d, err := time.Parse("2006-01-02", q.IncubatingTo)
 		if err != nil {
 			return "", fmt.Errorf("invalid incubating_to date: %w", err)
 		}
 		incToDate = &d
 	}
-	if acceptedFrom != "" {
-		d, err := time.Parse("2006-01-02", acceptedFrom)
+	if q.AcceptedFrom != "" {
+		d, err := time.Parse("2006-01-02", q.AcceptedFrom)
 		if err != nil {
 			return "", fmt.Errorf("invalid accepted_from date: %w", err)
 		}
 		accFromDate = &d
 	}
-	if acceptedTo != "" {
-		d, err := time.Parse("2006-01-02", acceptedTo)
+	if q.AcceptedTo != "" {
+		d, err := time.Parse("2006-01-02", q.AcceptedTo)
 		if err != nil {
 			return "", fmt.Errorf("invalid accepted_to date: %w", err)
 		}
@@ -259,16 +280,16 @@ func queryProjects(ds *Dataset, maturity, name, graduatedFrom, graduatedTo, incu
 	}
 
 	results := make([]projectResult, 0)
-	nameLower := strings.ToLower(name)
+	nameLower := strings.ToLower(q.Name)
 
 	for _, item := range ds.Items {
 		// Filter by maturity
-		if maturity != "" && !strings.EqualFold(item.Maturity, maturity) {
+		if q.Maturity != "" && !strings.EqualFold(item.Maturity, q.Maturity) {
 			continue
 		}
 
 		// Filter by name
-		if name != "" && !strings.Contains(strings.ToLower(item.Name), nameLower) {
+		if q.Name != "" && !strings.Contains(strings.ToLower(item.Name), nameLower) {
 			continue
 		}
 
@@ -333,7 +354,7 @@ func queryProjects(ds *Dataset, maturity, name, graduatedFrom, graduatedTo, incu
 		}
 
 		results = append(results, result)
-		if len(results) >= limit {
+		if len(results) >= q.Limit {
 			break
 		}
 	}
@@ -350,28 +371,28 @@ func queryProjects(ds *Dataset, maturity, name, graduatedFrom, graduatedTo, incu
 	return string(data), nil
 }
 
-// queryMembers filters and returns members based on tier and join dates
-func queryMembers(ds *Dataset, tier, joinedFrom, joinedTo string, limit int) (string, error) {
-	type memberResult struct {
-		Name              string `json:"name"`
-		Category          string `json:"category"`
-		Subcategory       string `json:"subcategory"`
-		MemberSubcategory string `json:"member_subcategory,omitempty"`
-		JoinedAt          string `json:"joined_at,omitempty"`
-	}
+// MemberQuery holds the parameters for querying members.
+type MemberQuery struct {
+	Tier       string
+	JoinedFrom string
+	JoinedTo   string
+	Limit      int
+}
 
+// queryMembers filters and returns members based on tier and join dates
+func queryMembers(ds *Dataset, q MemberQuery) (string, error) {
 	// Parse date filters
 	var joinFromDate, joinToDate *time.Time
 
-	if joinedFrom != "" {
-		d, err := time.Parse("2006-01-02", joinedFrom)
+	if q.JoinedFrom != "" {
+		d, err := time.Parse("2006-01-02", q.JoinedFrom)
 		if err != nil {
 			return "", fmt.Errorf("invalid joined_from date: %w", err)
 		}
 		joinFromDate = &d
 	}
-	if joinedTo != "" {
-		d, err := time.Parse("2006-01-02", joinedTo)
+	if q.JoinedTo != "" {
+		d, err := time.Parse("2006-01-02", q.JoinedTo)
 		if err != nil {
 			return "", fmt.Errorf("invalid joined_to date: %w", err)
 		}
@@ -387,7 +408,7 @@ func queryMembers(ds *Dataset, tier, joinedFrom, joinedTo string, limit int) (st
 		}
 
 		// Filter by tier
-		if tier != "" && !isMemberTier(item, tier) {
+		if q.Tier != "" && !isMemberTier(item, q.Tier) {
 			continue
 		}
 
@@ -414,7 +435,7 @@ func queryMembers(ds *Dataset, tier, joinedFrom, joinedTo string, limit int) (st
 		}
 
 		results = append(results, result)
-		if len(results) >= limit {
+		if len(results) >= q.Limit {
 			break
 		}
 	}
@@ -433,19 +454,8 @@ func queryMembers(ds *Dataset, tier, joinedFrom, joinedTo string, limit int) (st
 
 // getProjectDetails returns detailed information about a specific project
 func getProjectDetails(ds *Dataset, name string) (string, error) {
-	type projectDetail struct {
-		Name         string `json:"name"`
-		Category     string `json:"category"`
-		Subcategory  string `json:"subcategory"`
-		Maturity     string `json:"maturity,omitempty"`
-		AcceptedAt   string `json:"accepted_at,omitempty"`
-		IncubatingAt string `json:"incubating_at,omitempty"`
-		GraduatedAt  string `json:"graduated_at,omitempty"`
-		JoinedAt     string `json:"joined_at,omitempty"`
-	}
-
 	nameLower := strings.ToLower(name)
-	var matches []projectDetail
+	var matches []projectResult
 
 	for _, item := range ds.Items {
 		// Only include projects (items with maturity)
@@ -454,7 +464,7 @@ func getProjectDetails(ds *Dataset, name string) (string, error) {
 		}
 
 		if strings.Contains(strings.ToLower(item.Name), nameLower) {
-			detail := projectDetail{
+			detail := projectResult{
 				Name:        item.Name,
 				Category:    item.Category,
 				Subcategory: item.Subcategory,

--- a/utilities/landscape-mcp-server/metrics.go
+++ b/utilities/landscape-mcp-server/metrics.go
@@ -267,6 +267,8 @@ func membersJoinedByTier(ds *Dataset, tier string, year int) []string {
 type ProjectQuery struct {
 	Maturity       string
 	Name           string
+	Category       string
+	Subcategory    string
 	GraduatedFrom  string
 	GraduatedTo    string
 	IncubatingFrom string
@@ -330,6 +332,15 @@ func queryProjects(ds *Dataset, q ProjectQuery) (string, error) {
 	for _, item := range ds.Items {
 		// Filter by maturity
 		if q.Maturity != "" && !strings.EqualFold(item.Maturity, q.Maturity) {
+			continue
+		}
+
+		// Filter by category
+		if q.Category != "" && !strings.EqualFold(item.Category, q.Category) {
+			continue
+		}
+		// Filter by subcategory
+		if q.Subcategory != "" && !strings.EqualFold(item.Subcategory, q.Subcategory) {
 			continue
 		}
 

--- a/utilities/landscape-mcp-server/metrics.go
+++ b/utilities/landscape-mcp-server/metrics.go
@@ -430,6 +430,7 @@ func queryProjects(ds *Dataset, q ProjectQuery) (string, error) {
 // MemberQuery holds the parameters for querying members.
 type MemberQuery struct {
 	Tier       string
+	Category   string
 	JoinedFrom string
 	JoinedTo   string
 	Limit      int
@@ -465,6 +466,11 @@ func queryMembers(ds *Dataset, q MemberQuery) (string, error) {
 
 		// Filter by tier
 		if q.Tier != "" && !isMemberTier(item, q.Tier) {
+			continue
+		}
+
+		// Filter by category
+		if q.Category != "" && !strings.EqualFold(item.Category, q.Category) {
 			continue
 		}
 

--- a/utilities/landscape-mcp-server/metrics.go
+++ b/utilities/landscape-mcp-server/metrics.go
@@ -3,9 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
+)
+
+const (
+	defaultTopFundedLimit = 5
+	maxCompareProjects    = 10
 )
 
 type projectResult struct {
@@ -176,8 +182,12 @@ func encodeResult(metric string, payload map[string]interface{}) (string, error)
 	return string(data), nil
 }
 
+func isMember(item LandscapeItem) bool {
+	return strings.Contains(strings.ToLower(item.Category), "member")
+}
+
 func isMemberTier(item LandscapeItem, tier string) bool {
-	if !strings.Contains(strings.ToLower(item.Category), "member") {
+	if !isMember(item) {
 		return false
 	}
 	if strings.EqualFold(item.MemberSubcategory, tier) {
@@ -276,6 +286,7 @@ type ProjectQuery struct {
 	AcceptedFrom   string
 	AcceptedTo     string
 	Limit          int
+	Offset         int
 }
 
 // queryProjects filters and returns projects based on various criteria
@@ -328,6 +339,7 @@ func queryProjects(ds *Dataset, q ProjectQuery) (string, error) {
 
 	results := make([]projectResult, 0)
 	nameLower := strings.ToLower(q.Name)
+	skipped := 0
 
 	for _, item := range ds.Items {
 		// Filter by maturity
@@ -390,6 +402,12 @@ func queryProjects(ds *Dataset, q ProjectQuery) (string, error) {
 			continue
 		}
 
+		// Apply offset — skip matching items until we've skipped enough
+		if q.Offset > 0 && skipped < q.Offset {
+			skipped++
+			continue
+		}
+
 		result := projectResult{
 			Name:        item.Name,
 			Category:    item.Category,
@@ -434,6 +452,7 @@ type MemberQuery struct {
 	JoinedFrom string
 	JoinedTo   string
 	Limit      int
+	Offset     int
 }
 
 // queryMembers filters and returns members based on tier and join dates
@@ -457,10 +476,11 @@ func queryMembers(ds *Dataset, q MemberQuery) (string, error) {
 	}
 
 	results := make([]memberResult, 0)
+	skipped := 0
 
 	for _, item := range ds.Items {
 		// Only include members
-		if !strings.Contains(strings.ToLower(item.Category), "member") {
+		if !isMember(item) {
 			continue
 		}
 
@@ -484,6 +504,12 @@ func queryMembers(ds *Dataset, q MemberQuery) (string, error) {
 			if item.JoinedAt == nil || item.JoinedAt.After(*joinToDate) {
 				continue
 			}
+		}
+
+		// Apply offset — skip matching items until we've skipped enough
+		if q.Offset > 0 && skipped < q.Offset {
+			skipped++
+			continue
 		}
 
 		result := memberResult{
@@ -767,7 +793,7 @@ func landscapeSummary(ds *Dataset) (string, error) {
 		}
 
 		// Count members (items in a category containing "member")
-		if strings.Contains(strings.ToLower(item.Category), "member") {
+		if isMember(item) {
 			totalMembers++
 			tier := item.MemberSubcategory
 			if tier == "" {
@@ -860,8 +886,12 @@ func searchLandscape(ds *Dataset, query string, limit int) (string, error) {
 		if item.Maturity != "" {
 			result.Maturity = item.Maturity
 		}
-		if strings.Contains(strings.ToLower(item.Category), "member") {
-			result.MemberSubcategory = item.MemberSubcategory
+		if isMember(item) {
+			tier := item.MemberSubcategory
+			if tier == "" {
+				tier = item.Subcategory
+			}
+			result.MemberSubcategory = tier
 		}
 
 		results = append(results, result)
@@ -892,13 +922,294 @@ type memberDetailResult struct {
 	Organization      *orgSummary       `json:"organization,omitempty"`
 }
 
+// ---------------------------------------------------------------------------
+// Analytical tools
+// ---------------------------------------------------------------------------
+
+type comparisonProject struct {
+	Name         string            `json:"name"`
+	Category     string            `json:"category"`
+	Subcategory  string            `json:"subcategory"`
+	Maturity     string            `json:"maturity,omitempty"`
+	AcceptedAt   string            `json:"accepted_at,omitempty"`
+	IncubatingAt string            `json:"incubating_at,omitempty"`
+	GraduatedAt  string            `json:"graduated_at,omitempty"`
+	HomepageURL  string            `json:"homepage_url,omitempty"`
+	OSS          bool              `json:"oss"`
+	Description  string            `json:"description,omitempty"`
+	Repositories []Repository      `json:"repositories,omitempty"`
+	Links        map[string]string `json:"links,omitempty"`
+	Organization *orgSummary       `json:"organization,omitempty"`
+}
+
+// compareProjects returns a side-by-side comparison of named projects.
+func compareProjects(ds *Dataset, names []string) (string, error) {
+	if len(names) < 2 {
+		return "", fmt.Errorf("at least 2 project names are required for comparison")
+	}
+	if len(names) > maxCompareProjects {
+		return "", fmt.Errorf("maximum %d projects can be compared at once", maxCompareProjects)
+	}
+	for _, name := range names {
+		if strings.TrimSpace(name) == "" {
+			return "", fmt.Errorf("project name cannot be empty")
+		}
+	}
+
+	results := make([]comparisonProject, 0, len(names))
+	for _, name := range names {
+		nameLower := strings.ToLower(name)
+		var found *LandscapeItem
+		for i := range ds.Items {
+			item := &ds.Items[i]
+			if item.Maturity == "" {
+				continue
+			}
+			if strings.Contains(strings.ToLower(item.Name), nameLower) {
+				found = item
+				break
+			}
+		}
+		if found == nil {
+			return "", fmt.Errorf("project not found: %s", name)
+		}
+
+		cp := comparisonProject{
+			Name:        found.Name,
+			Category:    found.Category,
+			Subcategory: found.Subcategory,
+			Maturity:    found.Maturity,
+			HomepageURL: found.HomepageURL,
+			OSS:         found.OSS,
+			Description: found.Description,
+		}
+		if found.AcceptedAt != nil {
+			cp.AcceptedAt = found.AcceptedAt.Format("2006-01-02")
+		}
+		if found.IncubatingAt != nil {
+			cp.IncubatingAt = found.IncubatingAt.Format("2006-01-02")
+		}
+		if found.GraduatedAt != nil {
+			cp.GraduatedAt = found.GraduatedAt.Format("2006-01-02")
+		}
+		if len(found.Repositories) > 0 {
+			cp.Repositories = found.Repositories
+		}
+		cp.Links = buildLinks(*found)
+		if found.CrunchbaseURL != "" {
+			if org, ok := ds.CrunchbaseOrgs[found.CrunchbaseURL]; ok {
+				cp.Organization = buildOrgSummary(org)
+			}
+		}
+		results = append(results, cp)
+	}
+
+	response := map[string]interface{}{
+		"count":    len(results),
+		"projects": results,
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+type fundingKindSummary struct {
+	Count       int   `json:"count"`
+	TotalAmount int64 `json:"total_amount"`
+}
+
+type topFundedMember struct {
+	Name        string `json:"name"`
+	Tier        string `json:"tier"`
+	TotalAmount int64  `json:"total_amount"`
+	RoundCount  int    `json:"round_count"`
+}
+
+// fundingAnalysis analyzes funding data from Crunchbase for landscape members.
+func fundingAnalysis(ds *Dataset, tier string, year int) (string, error) {
+	totalMembersAnalyzed := 0
+	totalFundingRounds := 0
+	var totalFundingAmount int64
+	roundsByKind := make(map[string]*fundingKindSummary)
+	var memberFunding []topFundedMember
+
+	for _, item := range ds.Items {
+		if !isMember(item) {
+			continue
+		}
+		if tier != "" && !isMemberTier(item, tier) {
+			continue
+		}
+		if item.CrunchbaseURL == "" {
+			continue
+		}
+		org, ok := ds.CrunchbaseOrgs[item.CrunchbaseURL]
+		if !ok {
+			continue
+		}
+
+		totalMembersAnalyzed++
+		memberRoundCount := 0
+		var memberTotal int64
+
+		for _, round := range org.FundingRounds {
+			if year > 0 && round.AnnouncedOn != nil && round.AnnouncedOn.Year() != year {
+				continue
+			}
+			if year > 0 && round.AnnouncedOn == nil {
+				continue
+			}
+
+			totalFundingRounds++
+			memberRoundCount++
+
+			amt := int64(0)
+			if round.Amount != nil {
+				amt = *round.Amount
+			}
+			totalFundingAmount += amt
+			memberTotal += amt
+
+			kind := round.Kind
+			if kind == "" {
+				kind = "unknown"
+			}
+			if _, ok := roundsByKind[kind]; !ok {
+				roundsByKind[kind] = &fundingKindSummary{}
+			}
+			roundsByKind[kind].Count++
+			roundsByKind[kind].TotalAmount += amt
+		}
+
+		if memberRoundCount > 0 {
+			memberTier := item.MemberSubcategory
+			if memberTier == "" {
+				memberTier = item.Subcategory
+			}
+			memberFunding = append(memberFunding, topFundedMember{
+				Name:        item.Name,
+				Tier:        memberTier,
+				TotalAmount: memberTotal,
+				RoundCount:  memberRoundCount,
+			})
+		}
+	}
+
+	// Sort top_funded descending by total_amount
+	sort.Slice(memberFunding, func(i, j int) bool {
+		return memberFunding[i].TotalAmount > memberFunding[j].TotalAmount
+	})
+
+	// Limit to top funded members
+	topFunded := memberFunding
+	if len(topFunded) > defaultTopFundedLimit {
+		topFunded = topFunded[:defaultTopFundedLimit]
+	}
+
+	response := map[string]interface{}{
+		"total_members_analyzed": totalMembersAnalyzed,
+		"total_funding_rounds":   totalFundingRounds,
+		"total_funding_amount":   totalFundingAmount,
+		"rounds_by_kind":         roundsByKind,
+		"top_funded":             topFunded,
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+type geoDistributionEntry struct {
+	Name       string  `json:"name"`
+	Count      int     `json:"count"`
+	Percentage float64 `json:"percentage"`
+}
+
+// geographicDistribution returns a geographic breakdown of landscape items by Crunchbase location.
+func geographicDistribution(ds *Dataset, groupBy string) (string, error) {
+	if groupBy == "" {
+		groupBy = "country"
+	}
+	switch groupBy {
+	case "country", "region", "city":
+	default:
+		return "", fmt.Errorf("invalid group_by value: %q (must be country, region, or city)", groupBy)
+	}
+
+	totalAnalyzed := 0
+	counts := make(map[string]int)
+
+	for _, item := range ds.Items {
+		if item.CrunchbaseURL == "" {
+			continue
+		}
+		org, ok := ds.CrunchbaseOrgs[item.CrunchbaseURL]
+		if !ok {
+			continue
+		}
+		totalAnalyzed++
+
+		var field string
+		switch groupBy {
+		case "country":
+			field = org.Country
+		case "region":
+			field = org.Region
+		case "city":
+			field = org.City
+		}
+		if field != "" {
+			counts[field]++
+		}
+	}
+
+	totalWithLocation := 0
+	for _, c := range counts {
+		totalWithLocation += c
+	}
+	totalWithoutLocation := totalAnalyzed - totalWithLocation
+
+	// Build sorted distribution
+	distribution := make([]geoDistributionEntry, 0, len(counts))
+	for name, count := range counts {
+		pct := 0.0
+		if totalWithLocation > 0 {
+			pct = float64(count) / float64(totalWithLocation) * 100.0
+			// Round to 1 decimal place
+			pct = math.Round(pct*10) / 10
+		}
+		distribution = append(distribution, geoDistributionEntry{
+			Name:       name,
+			Count:      count,
+			Percentage: pct,
+		})
+	}
+	sort.Slice(distribution, func(i, j int) bool {
+		return distribution[i].Count > distribution[j].Count
+	})
+
+	response := map[string]interface{}{
+		"total_with_location":    totalWithLocation,
+		"total_without_location": totalWithoutLocation,
+		"distribution":           distribution,
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
 // getMemberDetails returns detailed information about a specific member
 func getMemberDetails(ds *Dataset, name string) (string, error) {
 	nameLower := strings.ToLower(name)
 	var matches []memberDetailResult
 
 	for _, item := range ds.Items {
-		if !strings.Contains(strings.ToLower(item.Category), "member") {
+		if !isMember(item) {
 			continue
 		}
 		if !strings.Contains(strings.ToLower(item.Name), nameLower) {

--- a/utilities/landscape-mcp-server/metrics.go
+++ b/utilities/landscape-mcp-server/metrics.go
@@ -676,3 +676,267 @@ func getProjectDetails(ds *Dataset, name string) (string, error) {
 	}
 	return string(data), nil
 }
+
+// ---------------------------------------------------------------------------
+// Discovery tools
+// ---------------------------------------------------------------------------
+
+type categoryResult struct {
+	Name          string              `json:"name"`
+	ItemCount     int                 `json:"item_count"`
+	Subcategories []subcategoryResult `json:"subcategories"`
+}
+
+type subcategoryResult struct {
+	Name      string `json:"name"`
+	ItemCount int    `json:"item_count"`
+}
+
+// listCategories returns all categories and subcategories with item counts.
+func listCategories(ds *Dataset) (string, error) {
+	catMap := make(map[string]map[string]int) // category -> subcategory -> count
+
+	for _, item := range ds.Items {
+		if _, ok := catMap[item.Category]; !ok {
+			catMap[item.Category] = make(map[string]int)
+		}
+		catMap[item.Category][item.Subcategory]++
+	}
+
+	// Build sorted result
+	catNames := make([]string, 0, len(catMap))
+	for name := range catMap {
+		catNames = append(catNames, name)
+	}
+	sort.Strings(catNames)
+
+	categories := make([]categoryResult, 0, len(catNames))
+	for _, catName := range catNames {
+		subs := catMap[catName]
+		subNames := make([]string, 0, len(subs))
+		for subName := range subs {
+			subNames = append(subNames, subName)
+		}
+		sort.Strings(subNames)
+
+		totalCount := 0
+		subcategories := make([]subcategoryResult, 0, len(subNames))
+		for _, subName := range subNames {
+			count := subs[subName]
+			totalCount += count
+			subcategories = append(subcategories, subcategoryResult{
+				Name:      subName,
+				ItemCount: count,
+			})
+		}
+
+		categories = append(categories, categoryResult{
+			Name:          catName,
+			ItemCount:     totalCount,
+			Subcategories: subcategories,
+		})
+	}
+
+	response := map[string]interface{}{
+		"categories": categories,
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// landscapeSummary provides a high-level statistical overview of the landscape.
+func landscapeSummary(ds *Dataset) (string, error) {
+	totalItems := len(ds.Items)
+	totalProjects := 0
+	totalMembers := 0
+	projectsByMaturity := make(map[string]int)
+	membersByTier := make(map[string]int)
+	categoriesSet := make(map[string]struct{})
+	itemsWithCB := 0
+
+	for _, item := range ds.Items {
+		categoriesSet[item.Category] = struct{}{}
+
+		// Count projects (items with non-empty maturity)
+		if item.Maturity != "" {
+			totalProjects++
+			projectsByMaturity[item.Maturity]++
+		}
+
+		// Count members (items in a category containing "member")
+		if strings.Contains(strings.ToLower(item.Category), "member") {
+			totalMembers++
+			tier := item.MemberSubcategory
+			if tier == "" {
+				tier = item.Subcategory
+			}
+			if tier != "" {
+				membersByTier[tier]++
+			}
+		}
+
+		// Count items with crunchbase data
+		if item.CrunchbaseURL != "" {
+			if _, ok := ds.CrunchbaseOrgs[item.CrunchbaseURL]; ok {
+				itemsWithCB++
+			}
+		}
+	}
+
+	response := map[string]interface{}{
+		"total_items":                totalItems,
+		"total_projects":             totalProjects,
+		"total_members":              totalMembers,
+		"projects_by_maturity":       projectsByMaturity,
+		"members_by_tier":            membersByTier,
+		"categories_count":           len(categoriesSet),
+		"items_with_crunchbase_data": itemsWithCB,
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+type searchResultItem struct {
+	Name              string   `json:"name"`
+	Category          string   `json:"category"`
+	Subcategory       string   `json:"subcategory"`
+	Maturity          string   `json:"maturity,omitempty"`
+	MemberSubcategory string   `json:"member_subcategory,omitempty"`
+	HomepageURL       string   `json:"homepage_url,omitempty"`
+	MatchFields       []string `json:"match_fields"`
+}
+
+// searchLandscape performs a case-insensitive substring search across items.
+func searchLandscape(ds *Dataset, query string, limit int) (string, error) {
+	if query == "" {
+		return "", fmt.Errorf("query parameter is required")
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	queryLower := strings.ToLower(query)
+	results := make([]searchResultItem, 0)
+
+	for _, item := range ds.Items {
+		var matchFields []string
+
+		if strings.Contains(strings.ToLower(item.Name), queryLower) {
+			matchFields = append(matchFields, "name")
+		}
+		if strings.Contains(strings.ToLower(item.Description), queryLower) {
+			matchFields = append(matchFields, "description")
+		}
+		if strings.Contains(strings.ToLower(item.Category), queryLower) {
+			matchFields = append(matchFields, "category")
+		}
+		if strings.Contains(strings.ToLower(item.Subcategory), queryLower) {
+			matchFields = append(matchFields, "subcategory")
+		}
+		if strings.Contains(strings.ToLower(item.HomepageURL), queryLower) {
+			matchFields = append(matchFields, "homepage_url")
+		}
+
+		if len(matchFields) == 0 {
+			continue
+		}
+
+		result := searchResultItem{
+			Name:        item.Name,
+			Category:    item.Category,
+			Subcategory: item.Subcategory,
+			HomepageURL: item.HomepageURL,
+			MatchFields: matchFields,
+		}
+		if item.Maturity != "" {
+			result.Maturity = item.Maturity
+		}
+		if strings.Contains(strings.ToLower(item.Category), "member") {
+			result.MemberSubcategory = item.MemberSubcategory
+		}
+
+		results = append(results, result)
+		if len(results) >= limit {
+			break
+		}
+	}
+
+	response := map[string]interface{}{
+		"count": len(results),
+		"items": results,
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+type memberDetailResult struct {
+	Name              string            `json:"name"`
+	Category          string            `json:"category"`
+	Subcategory       string            `json:"subcategory"`
+	MemberSubcategory string            `json:"member_subcategory,omitempty"`
+	JoinedAt          string            `json:"joined_at,omitempty"`
+	HomepageURL       string            `json:"homepage_url,omitempty"`
+	Links             map[string]string `json:"links,omitempty"`
+	Organization      *orgSummary       `json:"organization,omitempty"`
+}
+
+// getMemberDetails returns detailed information about a specific member
+func getMemberDetails(ds *Dataset, name string) (string, error) {
+	nameLower := strings.ToLower(name)
+	var matches []memberDetailResult
+
+	for _, item := range ds.Items {
+		if !strings.Contains(strings.ToLower(item.Category), "member") {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(item.Name), nameLower) {
+			continue
+		}
+
+		detail := memberDetailResult{
+			Name:              item.Name,
+			Category:          item.Category,
+			Subcategory:       item.Subcategory,
+			MemberSubcategory: item.MemberSubcategory,
+			HomepageURL:       item.HomepageURL,
+		}
+		if item.JoinedAt != nil {
+			detail.JoinedAt = item.JoinedAt.Format("2006-01-02")
+		}
+		// Build links
+		detail.Links = buildLinks(item)
+		// Look up Crunchbase org
+		if item.CrunchbaseURL != "" {
+			if org, ok := ds.CrunchbaseOrgs[item.CrunchbaseURL]; ok {
+				detail.Organization = buildOrgSummary(org)
+			}
+		}
+		matches = append(matches, detail)
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no member found matching name: %s", name)
+	}
+
+	response := map[string]interface{}{
+		"count":   len(matches),
+		"members": matches,
+	}
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/utilities/landscape-mcp-server/metrics_test.go
+++ b/utilities/landscape-mcp-server/metrics_test.go
@@ -219,6 +219,17 @@ func TestQueryMembers(t *testing.T) {
 			t.Errorf("count = %d, want 1", count)
 		}
 	})
+
+	t.Run("filter by category", func(t *testing.T) {
+		result, err := queryMembers(ds, MemberQuery{Category: "CNCF Members", Limit: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 3 {
+			t.Errorf("count = %d, want 3", count)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/utilities/landscape-mcp-server/metrics_test.go
+++ b/utilities/landscape-mcp-server/metrics_test.go
@@ -137,6 +137,36 @@ func TestQueryProjects(t *testing.T) {
 			t.Fatal("expected error for invalid date, got nil")
 		}
 	})
+
+	t.Run("filter by category", func(t *testing.T) {
+		result, err := queryProjects(ds, ProjectQuery{Category: "Provisioning", Limit: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+		names := jsonProjectNames(t, result)
+		if len(names) == 0 || names[0] != "Akri" {
+			t.Errorf("expected Akri, got %v", names)
+		}
+	})
+
+	t.Run("filter by subcategory", func(t *testing.T) {
+		result, err := queryProjects(ds, ProjectQuery{Subcategory: "Monitoring", Limit: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+		names := jsonProjectNames(t, result)
+		if len(names) == 0 || names[0] != "OpenTelemetry" {
+			t.Errorf("expected OpenTelemetry, got %v", names)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/utilities/landscape-mcp-server/metrics_test.go
+++ b/utilities/landscape-mcp-server/metrics_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -167,6 +169,85 @@ func TestQueryProjects(t *testing.T) {
 			t.Errorf("expected OpenTelemetry, got %v", names)
 		}
 	})
+
+	t.Run("offset skips first results", func(t *testing.T) {
+		// Get all 3 projects without offset
+		all, err := queryProjects(ds, ProjectQuery{Limit: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		allNames := jsonProjectNames(t, all)
+		if len(allNames) < 3 {
+			t.Fatalf("expected at least 3 projects, got %d", len(allNames))
+		}
+
+		// Offset=1 should skip the first project
+		result, err := queryProjects(ds, ProjectQuery{Limit: 100, Offset: 1})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 2 {
+			t.Errorf("count = %d, want 2", count)
+		}
+		names := jsonProjectNames(t, result)
+		// The first result after offset should be the second project from the full list
+		if len(names) == 0 || names[0] != allNames[1] {
+			t.Errorf("first project after offset = %v, want %q", names, allNames[1])
+		}
+	})
+
+	t.Run("offset beyond results returns empty", func(t *testing.T) {
+		result, err := queryProjects(ds, ProjectQuery{Limit: 100, Offset: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 0 {
+			t.Errorf("count = %d, want 0", count)
+		}
+	})
+
+	t.Run("offset with limit paginates correctly", func(t *testing.T) {
+		// Get all projects
+		all, err := queryProjects(ds, ProjectQuery{Limit: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		allNames := jsonProjectNames(t, all)
+
+		// Page 1: offset=0, limit=1
+		p1, err := queryProjects(ds, ProjectQuery{Limit: 1, Offset: 0})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p1Names := jsonProjectNames(t, p1)
+
+		// Page 2: offset=1, limit=1
+		p2, err := queryProjects(ds, ProjectQuery{Limit: 1, Offset: 1})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p2Names := jsonProjectNames(t, p2)
+
+		// Page 3: offset=2, limit=1
+		p3, err := queryProjects(ds, ProjectQuery{Limit: 1, Offset: 2})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p3Names := jsonProjectNames(t, p3)
+
+		// The three pages should cover all projects in order
+		if len(p1Names) != 1 || p1Names[0] != allNames[0] {
+			t.Errorf("page 1 = %v, want [%s]", p1Names, allNames[0])
+		}
+		if len(p2Names) != 1 || p2Names[0] != allNames[1] {
+			t.Errorf("page 2 = %v, want [%s]", p2Names, allNames[1])
+		}
+		if len(p3Names) != 1 || p3Names[0] != allNames[2] {
+			t.Errorf("page 3 = %v, want [%s]", p3Names, allNames[2])
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +309,77 @@ func TestQueryMembers(t *testing.T) {
 		count := jsonInt(t, result, "count")
 		if count != 3 {
 			t.Errorf("count = %d, want 3", count)
+		}
+	})
+
+	t.Run("offset skips first results", func(t *testing.T) {
+		all, err := queryMembers(ds, MemberQuery{Limit: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		allNames := jsonMemberNames(t, all)
+		if len(allNames) < 3 {
+			t.Fatalf("expected at least 3 members, got %d", len(allNames))
+		}
+
+		result, err := queryMembers(ds, MemberQuery{Limit: 100, Offset: 1})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 2 {
+			t.Errorf("count = %d, want 2", count)
+		}
+		names := jsonMemberNames(t, result)
+		if len(names) == 0 || names[0] != allNames[1] {
+			t.Errorf("first member after offset = %v, want %q", names, allNames[1])
+		}
+	})
+
+	t.Run("offset beyond results returns empty", func(t *testing.T) {
+		result, err := queryMembers(ds, MemberQuery{Limit: 100, Offset: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 0 {
+			t.Errorf("count = %d, want 0", count)
+		}
+	})
+
+	t.Run("offset with limit paginates correctly", func(t *testing.T) {
+		all, err := queryMembers(ds, MemberQuery{Limit: 100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		allNames := jsonMemberNames(t, all)
+
+		p1, err := queryMembers(ds, MemberQuery{Limit: 1, Offset: 0})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p1Names := jsonMemberNames(t, p1)
+
+		p2, err := queryMembers(ds, MemberQuery{Limit: 1, Offset: 1})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p2Names := jsonMemberNames(t, p2)
+
+		p3, err := queryMembers(ds, MemberQuery{Limit: 1, Offset: 2})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p3Names := jsonMemberNames(t, p3)
+
+		if len(p1Names) != 1 || p1Names[0] != allNames[0] {
+			t.Errorf("page 1 = %v, want [%s]", p1Names, allNames[0])
+		}
+		if len(p2Names) != 1 || p2Names[0] != allNames[1] {
+			t.Errorf("page 2 = %v, want [%s]", p2Names, allNames[1])
+		}
+		if len(p3Names) != 1 || p3Names[0] != allNames[2] {
+			t.Errorf("page 3 = %v, want [%s]", p3Names, allNames[2])
 		}
 	})
 }
@@ -1039,4 +1191,1086 @@ func jsonProjectNames(t *testing.T, jsonStr string) []string {
 		}
 	}
 	return names
+}
+
+func jsonMemberNames(t *testing.T, jsonStr string) []string {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+	members, ok := m["members"].([]interface{})
+	if !ok {
+		t.Fatalf("members is not an array")
+	}
+	names := make([]string, 0, len(members))
+	for _, p := range members {
+		pm, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := pm["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// ---------------------------------------------------------------------------
+// 6a: compareProjects tests
+// ---------------------------------------------------------------------------
+
+func TestCompareProjects(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("compare two projects", func(t *testing.T) {
+		result, err := compareProjects(ds, []string{"Kubernetes", "OpenTelemetry"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 2 {
+			t.Errorf("count = %d, want 2", count)
+		}
+
+		var resp struct {
+			Count    int `json:"count"`
+			Projects []struct {
+				Name        string `json:"name"`
+				Maturity    string `json:"maturity"`
+				Category    string `json:"category"`
+				Subcategory string `json:"subcategory"`
+			} `json:"projects"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if resp.Projects[0].Name != "Kubernetes" {
+			t.Errorf("first project = %q, want %q", resp.Projects[0].Name, "Kubernetes")
+		}
+		if resp.Projects[1].Name != "OpenTelemetry" {
+			t.Errorf("second project = %q, want %q", resp.Projects[1].Name, "OpenTelemetry")
+		}
+		if resp.Projects[0].Maturity != "graduated" {
+			t.Errorf("Kubernetes maturity = %q, want %q", resp.Projects[0].Maturity, "graduated")
+		}
+		if resp.Projects[1].Maturity != "incubating" {
+			t.Errorf("OpenTelemetry maturity = %q, want %q", resp.Projects[1].Maturity, "incubating")
+		}
+	})
+
+	t.Run("compare three projects", func(t *testing.T) {
+		result, err := compareProjects(ds, []string{"Kubernetes", "OpenTelemetry", "Akri"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 3 {
+			t.Errorf("count = %d, want 3", count)
+		}
+	})
+
+	t.Run("case-insensitive lookup", func(t *testing.T) {
+		result, err := compareProjects(ds, []string{"kubernetes", "opentelemetry"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 2 {
+			t.Errorf("count = %d, want 2", count)
+		}
+	})
+
+	t.Run("nonexistent project returns error", func(t *testing.T) {
+		_, err := compareProjects(ds, []string{"Kubernetes", "NonExistent"})
+		if err == nil {
+			t.Fatal("expected error for nonexistent project, got nil")
+		}
+	})
+
+	t.Run("fewer than 2 names returns error", func(t *testing.T) {
+		_, err := compareProjects(ds, []string{"Kubernetes"})
+		if err == nil {
+			t.Fatal("expected error for single project, got nil")
+		}
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		_, err := compareProjects(ds, []string{"", "Kubernetes"})
+		if err == nil {
+			t.Fatal("expected error for empty project name, got nil")
+		}
+	})
+
+	t.Run("more than 10 names returns error", func(t *testing.T) {
+		names := make([]string, 11)
+		for i := range names {
+			names[i] = "Kubernetes"
+		}
+		_, err := compareProjects(ds, names)
+		if err == nil {
+			t.Fatal("expected error for too many names, got nil")
+		}
+	})
+
+	t.Run("includes enriched fields", func(t *testing.T) {
+		result, err := compareProjects(ds, []string{"Kubernetes", "Akri"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Projects []struct {
+				Name         string            `json:"name"`
+				HomepageURL  string            `json:"homepage_url"`
+				OSS          bool              `json:"oss"`
+				Description  string            `json:"description"`
+				Repositories []Repository      `json:"repositories"`
+				Links        map[string]string `json:"links"`
+				Organization *orgSummary       `json:"organization"`
+			} `json:"projects"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		// Kubernetes should have homepage, repos, links
+		k := resp.Projects[0]
+		if k.HomepageURL != "https://kubernetes.io/" {
+			t.Errorf("Kubernetes homepage_url = %q", k.HomepageURL)
+		}
+		if !k.OSS {
+			t.Error("expected Kubernetes oss = true")
+		}
+		if len(k.Repositories) != 2 {
+			t.Errorf("Kubernetes repositories count = %d, want 2", len(k.Repositories))
+		}
+		if k.Links == nil {
+			t.Error("expected non-nil links for Kubernetes")
+		}
+	})
+
+	t.Run("does not match members", func(t *testing.T) {
+		_, err := compareProjects(ds, []string{"Kubernetes", "TestGoldCorp"})
+		if err == nil {
+			t.Fatal("expected error since TestGoldCorp is a member, not a project")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 6b: fundingAnalysis tests
+// ---------------------------------------------------------------------------
+
+func TestFundingAnalysis(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("all members no filters", func(t *testing.T) {
+		result, err := fundingAnalysis(ds, "", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalMembersAnalyzed int                        `json:"total_members_analyzed"`
+			TotalFundingRounds   int                        `json:"total_funding_rounds"`
+			TotalFundingAmount   int64                      `json:"total_funding_amount"`
+			RoundsByKind         map[string]json.RawMessage `json:"rounds_by_kind"`
+			TopFunded            []struct {
+				Name        string `json:"name"`
+				Tier        string `json:"tier"`
+				TotalAmount int64  `json:"total_amount"`
+				RoundCount  int    `json:"round_count"`
+			} `json:"top_funded"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// 2 members have crunchbase data (TestGoldCorp, TestSilverInc)
+		if resp.TotalMembersAnalyzed != 2 {
+			t.Errorf("total_members_analyzed = %d, want 2", resp.TotalMembersAnalyzed)
+		}
+		// 3 total rounds: series_b, series_a, seed
+		if resp.TotalFundingRounds != 3 {
+			t.Errorf("total_funding_rounds = %d, want 3", resp.TotalFundingRounds)
+		}
+		// 50M + 20M + 10M = 80M
+		if resp.TotalFundingAmount != 80000000 {
+			t.Errorf("total_funding_amount = %d, want 80000000", resp.TotalFundingAmount)
+		}
+		// 3 kinds: series_a, series_b, seed
+		if len(resp.RoundsByKind) != 3 {
+			t.Errorf("rounds_by_kind count = %d, want 3", len(resp.RoundsByKind))
+		}
+		// Top funded: TestGoldCorp (70M) first, TestSilverInc (10M) second
+		if len(resp.TopFunded) != 2 {
+			t.Fatalf("top_funded count = %d, want 2", len(resp.TopFunded))
+		}
+		if resp.TopFunded[0].Name != "TestGoldCorp" {
+			t.Errorf("top_funded[0].name = %q, want %q", resp.TopFunded[0].Name, "TestGoldCorp")
+		}
+		if resp.TopFunded[0].TotalAmount != 70000000 {
+			t.Errorf("top_funded[0].total_amount = %d, want 70000000", resp.TopFunded[0].TotalAmount)
+		}
+		if resp.TopFunded[0].RoundCount != 2 {
+			t.Errorf("top_funded[0].round_count = %d, want 2", resp.TopFunded[0].RoundCount)
+		}
+		if resp.TopFunded[0].Tier != "Gold" {
+			t.Errorf("top_funded[0].tier = %q, want %q", resp.TopFunded[0].Tier, "Gold")
+		}
+		if resp.TopFunded[1].Name != "TestSilverInc" {
+			t.Errorf("top_funded[1].name = %q, want %q", resp.TopFunded[1].Name, "TestSilverInc")
+		}
+		if resp.TopFunded[1].TotalAmount != 10000000 {
+			t.Errorf("top_funded[1].total_amount = %d, want 10000000", resp.TopFunded[1].TotalAmount)
+		}
+	})
+
+	t.Run("filter by tier Gold", func(t *testing.T) {
+		result, err := fundingAnalysis(ds, "Gold", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalMembersAnalyzed int   `json:"total_members_analyzed"`
+			TotalFundingRounds   int   `json:"total_funding_rounds"`
+			TotalFundingAmount   int64 `json:"total_funding_amount"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.TotalMembersAnalyzed != 1 {
+			t.Errorf("total_members_analyzed = %d, want 1", resp.TotalMembersAnalyzed)
+		}
+		if resp.TotalFundingRounds != 2 {
+			t.Errorf("total_funding_rounds = %d, want 2", resp.TotalFundingRounds)
+		}
+		// 50M + 20M = 70M
+		if resp.TotalFundingAmount != 70000000 {
+			t.Errorf("total_funding_amount = %d, want 70000000", resp.TotalFundingAmount)
+		}
+	})
+
+	t.Run("filter by year 2026", func(t *testing.T) {
+		result, err := fundingAnalysis(ds, "", 2026)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalMembersAnalyzed int   `json:"total_members_analyzed"`
+			TotalFundingRounds   int   `json:"total_funding_rounds"`
+			TotalFundingAmount   int64 `json:"total_funding_amount"`
+			TopFunded            []struct {
+				Name       string `json:"name"`
+				RoundCount int    `json:"round_count"`
+			} `json:"top_funded"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// Both members analyzed (they have CB data), but only 2026 rounds count
+		// TestGoldCorp: series_b 2026-01-10 ($50M) — matches
+		// TestGoldCorp: series_a 2025-06-15 ($20M) — does NOT match
+		// TestSilverInc: seed 2026-02-01 ($10M) — matches
+		if resp.TotalFundingRounds != 2 {
+			t.Errorf("total_funding_rounds = %d, want 2", resp.TotalFundingRounds)
+		}
+		// 50M + 10M = 60M
+		if resp.TotalFundingAmount != 60000000 {
+			t.Errorf("total_funding_amount = %d, want 60000000", resp.TotalFundingAmount)
+		}
+	})
+
+	t.Run("filter by tier and year", func(t *testing.T) {
+		result, err := fundingAnalysis(ds, "Gold", 2026)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalMembersAnalyzed int   `json:"total_members_analyzed"`
+			TotalFundingRounds   int   `json:"total_funding_rounds"`
+			TotalFundingAmount   int64 `json:"total_funding_amount"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.TotalMembersAnalyzed != 1 {
+			t.Errorf("total_members_analyzed = %d, want 1", resp.TotalMembersAnalyzed)
+		}
+		// Only series_b from 2026 matches
+		if resp.TotalFundingRounds != 1 {
+			t.Errorf("total_funding_rounds = %d, want 1", resp.TotalFundingRounds)
+		}
+		if resp.TotalFundingAmount != 50000000 {
+			t.Errorf("total_funding_amount = %d, want 50000000", resp.TotalFundingAmount)
+		}
+	})
+
+	t.Run("tier with no crunchbase data", func(t *testing.T) {
+		result, err := fundingAnalysis(ds, "Platinum", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalMembersAnalyzed int `json:"total_members_analyzed"`
+			TotalFundingRounds   int `json:"total_funding_rounds"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.TotalMembersAnalyzed != 0 {
+			t.Errorf("total_members_analyzed = %d, want 0", resp.TotalMembersAnalyzed)
+		}
+		if resp.TotalFundingRounds != 0 {
+			t.Errorf("total_funding_rounds = %d, want 0", resp.TotalFundingRounds)
+		}
+	})
+
+	t.Run("rounds_by_kind breakdown", func(t *testing.T) {
+		result, err := fundingAnalysis(ds, "", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			RoundsByKind map[string]struct {
+				Count       int   `json:"count"`
+				TotalAmount int64 `json:"total_amount"`
+			} `json:"rounds_by_kind"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		seriesB, ok := resp.RoundsByKind["series_b"]
+		if !ok {
+			t.Fatal("series_b not found in rounds_by_kind")
+		}
+		if seriesB.Count != 1 || seriesB.TotalAmount != 50000000 {
+			t.Errorf("series_b = {count:%d, total:%d}, want {1, 50000000}", seriesB.Count, seriesB.TotalAmount)
+		}
+
+		seriesA, ok := resp.RoundsByKind["series_a"]
+		if !ok {
+			t.Fatal("series_a not found in rounds_by_kind")
+		}
+		if seriesA.Count != 1 || seriesA.TotalAmount != 20000000 {
+			t.Errorf("series_a = {count:%d, total:%d}, want {1, 20000000}", seriesA.Count, seriesA.TotalAmount)
+		}
+
+		seed, ok := resp.RoundsByKind["seed"]
+		if !ok {
+			t.Fatal("seed not found in rounds_by_kind")
+		}
+		if seed.Count != 1 || seed.TotalAmount != 10000000 {
+			t.Errorf("seed = {count:%d, total:%d}, want {1, 10000000}", seed.Count, seed.TotalAmount)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 6c: geographicDistribution tests
+// ---------------------------------------------------------------------------
+
+func TestGeographicDistribution(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("default group_by country", func(t *testing.T) {
+		result, err := geographicDistribution(ds, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalWithLocation    int `json:"total_with_location"`
+			TotalWithoutLocation int `json:"total_without_location"`
+			Distribution         []struct {
+				Name       string  `json:"name"`
+				Count      int     `json:"count"`
+				Percentage float64 `json:"percentage"`
+			} `json:"distribution"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// TestGoldCorp has country, TestSilverInc does not
+		if resp.TotalWithLocation != 1 {
+			t.Errorf("total_with_location = %d, want 1", resp.TotalWithLocation)
+		}
+		if resp.TotalWithoutLocation != 1 {
+			t.Errorf("total_without_location = %d, want 1", resp.TotalWithoutLocation)
+		}
+		if len(resp.Distribution) != 1 {
+			t.Fatalf("distribution count = %d, want 1", len(resp.Distribution))
+		}
+		if resp.Distribution[0].Name != "United States" {
+			t.Errorf("distribution[0].name = %q, want %q", resp.Distribution[0].Name, "United States")
+		}
+		if resp.Distribution[0].Count != 1 {
+			t.Errorf("distribution[0].count = %d, want 1", resp.Distribution[0].Count)
+		}
+		if resp.Distribution[0].Percentage != 100.0 {
+			t.Errorf("distribution[0].percentage = %f, want 100.0", resp.Distribution[0].Percentage)
+		}
+	})
+
+	t.Run("group_by region", func(t *testing.T) {
+		result, err := geographicDistribution(ds, "region")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalWithLocation int `json:"total_with_location"`
+			Distribution      []struct {
+				Name string `json:"name"`
+			} `json:"distribution"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.TotalWithLocation != 1 {
+			t.Errorf("total_with_location = %d, want 1", resp.TotalWithLocation)
+		}
+		if len(resp.Distribution) != 1 {
+			t.Fatalf("distribution count = %d, want 1", len(resp.Distribution))
+		}
+		if resp.Distribution[0].Name != "North America" {
+			t.Errorf("distribution[0].name = %q, want %q", resp.Distribution[0].Name, "North America")
+		}
+	})
+
+	t.Run("group_by city", func(t *testing.T) {
+		result, err := geographicDistribution(ds, "city")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalWithLocation int `json:"total_with_location"`
+			Distribution      []struct {
+				Name string `json:"name"`
+			} `json:"distribution"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.TotalWithLocation != 1 {
+			t.Errorf("total_with_location = %d, want 1", resp.TotalWithLocation)
+		}
+		if len(resp.Distribution) != 1 {
+			t.Fatalf("distribution count = %d, want 1", len(resp.Distribution))
+		}
+		if resp.Distribution[0].Name != "San Francisco" {
+			t.Errorf("distribution[0].name = %q, want %q", resp.Distribution[0].Name, "San Francisco")
+		}
+	})
+
+	t.Run("invalid group_by returns error", func(t *testing.T) {
+		_, err := geographicDistribution(ds, "invalid")
+		if err == nil {
+			t.Fatal("expected error for invalid group_by, got nil")
+		}
+	})
+
+	t.Run("explicit country group_by", func(t *testing.T) {
+		result, err := geographicDistribution(ds, "country")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			TotalWithLocation int `json:"total_with_location"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.TotalWithLocation != 1 {
+			t.Errorf("total_with_location = %d, want 1", resp.TotalWithLocation)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// MCP Resources handler tests
+// ---------------------------------------------------------------------------
+
+func TestHandleResourcesList(t *testing.T) {
+	cfg := LandscapeConfig{Name: "TestLandscape", Description: "Test"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "resources/list",
+		ID:      json.RawMessage(`1`),
+	}
+
+	resp := handleResourcesList(req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Resources []struct {
+			URI         string `json:"uri"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			MimeType    string `json:"mimeType"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if len(result.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(result.Resources))
+	}
+
+	// Verify categories resource
+	cat := result.Resources[0]
+	if cat.URI != "landscape://categories" {
+		t.Errorf("resource[0].uri = %q, want %q", cat.URI, "landscape://categories")
+	}
+	if cat.Name != "TestLandscape Categories" {
+		t.Errorf("resource[0].name = %q, want %q", cat.Name, "TestLandscape Categories")
+	}
+	if cat.MimeType != "application/json" {
+		t.Errorf("resource[0].mimeType = %q, want %q", cat.MimeType, "application/json")
+	}
+
+	// Verify summary resource
+	sum := result.Resources[1]
+	if sum.URI != "landscape://summary" {
+		t.Errorf("resource[1].uri = %q, want %q", sum.URI, "landscape://summary")
+	}
+	if sum.Name != "TestLandscape Summary" {
+		t.Errorf("resource[1].name = %q, want %q", sum.Name, "TestLandscape Summary")
+	}
+	if sum.MimeType != "application/json" {
+		t.Errorf("resource[1].mimeType = %q, want %q", sum.MimeType, "application/json")
+	}
+}
+
+func TestHandleResourcesReadCategories(t *testing.T) {
+	ds := loadTestDataset(t)
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+	state.setDataset(ds, nil)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{"uri":"landscape://categories"}`),
+		ID:      json.RawMessage(`2`),
+	}
+
+	resp := handleResourcesRead(context.Background(), req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Contents []struct {
+			URI      string `json:"uri"`
+			MimeType string `json:"mimeType"`
+			Text     string `json:"text"`
+		} `json:"contents"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if len(result.Contents) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Contents))
+	}
+
+	content := result.Contents[0]
+	if content.URI != "landscape://categories" {
+		t.Errorf("content.uri = %q, want %q", content.URI, "landscape://categories")
+	}
+	if content.MimeType != "application/json" {
+		t.Errorf("content.mimeType = %q, want %q", content.MimeType, "application/json")
+	}
+
+	// Verify the text is valid JSON containing categories
+	var catData struct {
+		Categories []struct {
+			Name string `json:"name"`
+		} `json:"categories"`
+	}
+	if err := json.Unmarshal([]byte(content.Text), &catData); err != nil {
+		t.Fatalf("content.text is not valid JSON: %v", err)
+	}
+	if len(catData.Categories) == 0 {
+		t.Error("expected at least one category")
+	}
+}
+
+func TestHandleResourcesReadSummary(t *testing.T) {
+	ds := loadTestDataset(t)
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+	state.setDataset(ds, nil)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{"uri":"landscape://summary"}`),
+		ID:      json.RawMessage(`3`),
+	}
+
+	resp := handleResourcesRead(context.Background(), req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Contents []struct {
+			URI      string `json:"uri"`
+			MimeType string `json:"mimeType"`
+			Text     string `json:"text"`
+		} `json:"contents"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if len(result.Contents) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Contents))
+	}
+
+	content := result.Contents[0]
+	if content.URI != "landscape://summary" {
+		t.Errorf("content.uri = %q, want %q", content.URI, "landscape://summary")
+	}
+	if content.MimeType != "application/json" {
+		t.Errorf("content.mimeType = %q, want %q", content.MimeType, "application/json")
+	}
+
+	// Verify the text is valid JSON containing summary data
+	var summaryData struct {
+		TotalItems    int `json:"total_items"`
+		TotalProjects int `json:"total_projects"`
+	}
+	if err := json.Unmarshal([]byte(content.Text), &summaryData); err != nil {
+		t.Fatalf("content.text is not valid JSON: %v", err)
+	}
+	if summaryData.TotalItems == 0 {
+		t.Error("expected total_items > 0")
+	}
+}
+
+func TestHandleResourcesReadUnknownURI(t *testing.T) {
+	ds := loadTestDataset(t)
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+	state.setDataset(ds, nil)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{"uri":"landscape://unknown"}`),
+		ID:      json.RawMessage(`4`),
+	}
+
+	resp := handleResourcesRead(context.Background(), req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown URI, got success")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, -32602)
+	}
+}
+
+func TestHandleResourcesReadInvalidParams(t *testing.T) {
+	ds := loadTestDataset(t)
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+	state.setDataset(ds, nil)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{invalid`),
+		ID:      json.RawMessage(`5`),
+	}
+
+	resp := handleResourcesRead(context.Background(), req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid params, got success")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, -32602)
+	}
+}
+
+func TestInitializeIncludesResourcesCapability(t *testing.T) {
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		ID:      json.RawMessage(`1`),
+	}
+
+	resp := handleRequest(context.Background(), req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Capabilities struct {
+			Tools     map[string]interface{} `json:"tools"`
+			Resources map[string]interface{} `json:"resources"`
+		} `json:"capabilities"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if result.Capabilities.Tools == nil {
+		t.Error("expected tools capability to be present")
+	}
+	if result.Capabilities.Resources == nil {
+		t.Error("expected resources capability to be present")
+	}
+}
+
+func TestResourcesDispatchViaHandleRequest(t *testing.T) {
+	ds := loadTestDataset(t)
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+	state.setDataset(ds, nil)
+
+	// Test resources/list dispatch
+	listReq := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "resources/list",
+		ID:      json.RawMessage(`10`),
+	}
+	listResp := handleRequest(context.Background(), listReq, state)
+	if listResp == nil {
+		t.Fatal("resources/list: expected response, got nil")
+	}
+	if listResp.Error != nil {
+		t.Fatalf("resources/list: unexpected error: %s", listResp.Error.Message)
+	}
+
+	// Test resources/read dispatch
+	readReq := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{"uri":"landscape://summary"}`),
+		ID:      json.RawMessage(`11`),
+	}
+	readResp := handleRequest(context.Background(), readReq, state)
+	if readResp == nil {
+		t.Fatal("resources/read: expected response, got nil")
+	}
+	if readResp.Error != nil {
+		t.Fatalf("resources/read: unexpected error: %s", readResp.Error.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Prompts tests
+// ---------------------------------------------------------------------------
+
+func TestHandlePromptsList(t *testing.T) {
+	cfg := LandscapeConfig{Name: "TestLandscape", Description: "Test"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "prompts/list",
+		ID:      json.RawMessage(`1`),
+	}
+
+	resp := handlePromptsList(req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Prompts []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Arguments   []struct {
+				Name        string `json:"name"`
+				Description string `json:"description"`
+				Required    bool   `json:"required"`
+			} `json:"arguments"`
+		} `json:"prompts"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if len(result.Prompts) != 2 {
+		t.Fatalf("expected 2 prompts, got %d", len(result.Prompts))
+	}
+
+	// Verify analyze_landscape prompt
+	analyze := result.Prompts[0]
+	if analyze.Name != "analyze_landscape" {
+		t.Errorf("prompts[0].name = %q, want %q", analyze.Name, "analyze_landscape")
+	}
+	if analyze.Description != "Analyze the current state of the TestLandscape landscape" {
+		t.Errorf("prompts[0].description = %q, want %q", analyze.Description, "Analyze the current state of the TestLandscape landscape")
+	}
+	if len(analyze.Arguments) != 0 {
+		t.Errorf("prompts[0].arguments length = %d, want 0", len(analyze.Arguments))
+	}
+
+	// Verify compare_projects prompt
+	compare := result.Prompts[1]
+	if compare.Name != "compare_projects" {
+		t.Errorf("prompts[1].name = %q, want %q", compare.Name, "compare_projects")
+	}
+	if compare.Description != "Compare specific projects in the TestLandscape landscape" {
+		t.Errorf("prompts[1].description = %q, want %q", compare.Description, "Compare specific projects in the TestLandscape landscape")
+	}
+	if len(compare.Arguments) != 1 {
+		t.Fatalf("prompts[1].arguments length = %d, want 1", len(compare.Arguments))
+	}
+	if compare.Arguments[0].Name != "project_names" {
+		t.Errorf("prompts[1].arguments[0].name = %q, want %q", compare.Arguments[0].Name, "project_names")
+	}
+	if !compare.Arguments[0].Required {
+		t.Error("prompts[1].arguments[0].required should be true")
+	}
+}
+
+func TestHandlePromptsGetAnalyzeLandscape(t *testing.T) {
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{"name":"analyze_landscape"}`),
+		ID:      json.RawMessage(`1`),
+	}
+
+	resp := handlePromptsGet(req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Description string `json:"description"`
+		Messages    []struct {
+			Role    string `json:"role"`
+			Content struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if result.Description != "Analyze the current state of the CNCF landscape" {
+		t.Errorf("description = %q, want %q", result.Description, "Analyze the current state of the CNCF landscape")
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	msg := result.Messages[0]
+	if msg.Role != "user" {
+		t.Errorf("message.role = %q, want %q", msg.Role, "user")
+	}
+	if msg.Content.Type != "text" {
+		t.Errorf("message.content.type = %q, want %q", msg.Content.Type, "text")
+	}
+	if !strings.Contains(msg.Content.Text, "CNCF landscape") {
+		t.Error("message text should contain 'CNCF landscape'")
+	}
+	if !strings.Contains(msg.Content.Text, "landscape_summary") {
+		t.Error("message text should reference landscape_summary tool")
+	}
+}
+
+func TestHandlePromptsGetCompareProjects(t *testing.T) {
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{"name":"compare_projects","arguments":{"project_names":"Kubernetes,Envoy"}}`),
+		ID:      json.RawMessage(`2`),
+	}
+
+	resp := handlePromptsGet(req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Description string `json:"description"`
+		Messages    []struct {
+			Role    string `json:"role"`
+			Content struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if result.Description != "Compare specific projects in the CNCF landscape" {
+		t.Errorf("description = %q, want %q", result.Description, "Compare specific projects in the CNCF landscape")
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	msg := result.Messages[0]
+	if msg.Role != "user" {
+		t.Errorf("message.role = %q, want %q", msg.Role, "user")
+	}
+	if msg.Content.Type != "text" {
+		t.Errorf("message.content.type = %q, want %q", msg.Content.Type, "text")
+	}
+	if !strings.Contains(msg.Content.Text, "Kubernetes,Envoy") {
+		t.Error("message text should contain project names 'Kubernetes,Envoy'")
+	}
+	if !strings.Contains(msg.Content.Text, "compare_projects") {
+		t.Error("message text should reference compare_projects tool")
+	}
+}
+
+func TestHandlePromptsGetUnknown(t *testing.T) {
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{"name":"nonexistent_prompt"}`),
+		ID:      json.RawMessage(`3`),
+	}
+
+	resp := handlePromptsGet(req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown prompt, got success")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, -32602)
+	}
+	if !strings.Contains(resp.Error.Message, "Unknown prompt") {
+		t.Errorf("error message = %q, want it to contain 'Unknown prompt'", resp.Error.Message)
+	}
+}
+
+func TestHandlePromptsGetMissingArgument(t *testing.T) {
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{"name":"compare_projects"}`),
+		ID:      json.RawMessage(`4`),
+	}
+
+	resp := handlePromptsGet(req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for missing project_names argument, got success")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, -32602)
+	}
+	if !strings.Contains(resp.Error.Message, "project_names") {
+		t.Errorf("error message = %q, want it to contain 'project_names'", resp.Error.Message)
+	}
+}
+
+func TestInitializeIncludesPromptsCapability(t *testing.T) {
+	cfg := LandscapeConfig{Name: "CNCF", Description: "Cloud Native Computing Foundation"}
+	state := newServerState(cfg)
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		ID:      json.RawMessage(`1`),
+	}
+
+	resp := handleRequest(context.Background(), req, state)
+	if resp == nil {
+		t.Fatal("expected response, got nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	var result struct {
+		Capabilities struct {
+			Tools     map[string]interface{} `json:"tools"`
+			Resources map[string]interface{} `json:"resources"`
+			Prompts   map[string]interface{} `json:"prompts"`
+		} `json:"capabilities"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	if result.Capabilities.Tools == nil {
+		t.Error("expected tools capability to be present")
+	}
+	if result.Capabilities.Resources == nil {
+		t.Error("expected resources capability to be present")
+	}
+	if result.Capabilities.Prompts == nil {
+		t.Error("expected prompts capability to be present")
+	}
 }

--- a/utilities/landscape-mcp-server/metrics_test.go
+++ b/utilities/landscape-mcp-server/metrics_test.go
@@ -73,7 +73,7 @@ func TestQueryProjects(t *testing.T) {
 	ds := loadTestDataset(t)
 
 	t.Run("no filters returns all projects", func(t *testing.T) {
-		result, err := queryProjects(ds, "", "", "", "", "", "", "", "", 100)
+		result, err := queryProjects(ds, ProjectQuery{Limit: 100})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -84,7 +84,7 @@ func TestQueryProjects(t *testing.T) {
 	})
 
 	t.Run("filter by maturity graduated", func(t *testing.T) {
-		result, err := queryProjects(ds, "graduated", "", "", "", "", "", "", "", 100)
+		result, err := queryProjects(ds, ProjectQuery{Maturity: "graduated", Limit: 100})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -95,7 +95,7 @@ func TestQueryProjects(t *testing.T) {
 	})
 
 	t.Run("filter by name case-insensitive substring", func(t *testing.T) {
-		result, err := queryProjects(ds, "", "kube", "", "", "", "", "", "", 100)
+		result, err := queryProjects(ds, ProjectQuery{Name: "kube", Limit: 100})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -110,7 +110,7 @@ func TestQueryProjects(t *testing.T) {
 	})
 
 	t.Run("filter by graduated date range", func(t *testing.T) {
-		result, err := queryProjects(ds, "", "", "2018-01-01", "2019-01-01", "", "", "", "", 100)
+		result, err := queryProjects(ds, ProjectQuery{GraduatedFrom: "2018-01-01", GraduatedTo: "2019-01-01", Limit: 100})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -121,7 +121,7 @@ func TestQueryProjects(t *testing.T) {
 	})
 
 	t.Run("limit constrains results", func(t *testing.T) {
-		result, err := queryProjects(ds, "", "", "", "", "", "", "", "", 1)
+		result, err := queryProjects(ds, ProjectQuery{Limit: 1})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -132,7 +132,7 @@ func TestQueryProjects(t *testing.T) {
 	})
 
 	t.Run("invalid date returns error", func(t *testing.T) {
-		_, err := queryProjects(ds, "", "", "bad-date", "", "", "", "", "", 100)
+		_, err := queryProjects(ds, ProjectQuery{GraduatedFrom: "bad-date", Limit: 100})
 		if err == nil {
 			t.Fatal("expected error for invalid date, got nil")
 		}
@@ -147,7 +147,7 @@ func TestQueryMembers(t *testing.T) {
 	ds := loadTestDataset(t)
 
 	t.Run("no filters returns all members", func(t *testing.T) {
-		result, err := queryMembers(ds, "", "", "", 100)
+		result, err := queryMembers(ds, MemberQuery{Limit: 100})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -158,7 +158,7 @@ func TestQueryMembers(t *testing.T) {
 	})
 
 	t.Run("filter by tier Gold", func(t *testing.T) {
-		result, err := queryMembers(ds, "Gold", "", "", 100)
+		result, err := queryMembers(ds, MemberQuery{Tier: "Gold", Limit: 100})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -169,7 +169,7 @@ func TestQueryMembers(t *testing.T) {
 	})
 
 	t.Run("filter by joined_from", func(t *testing.T) {
-		result, err := queryMembers(ds, "", "2026-01-01", "", 100)
+		result, err := queryMembers(ds, MemberQuery{JoinedFrom: "2026-01-01", Limit: 100})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -180,7 +180,7 @@ func TestQueryMembers(t *testing.T) {
 	})
 
 	t.Run("limit constrains results", func(t *testing.T) {
-		result, err := queryMembers(ds, "", "", "", 1)
+		result, err := queryMembers(ds, MemberQuery{Limit: 1})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/utilities/landscape-mcp-server/metrics_test.go
+++ b/utilities/landscape-mcp-server/metrics_test.go
@@ -226,6 +226,56 @@ func TestGetProjectDetails(t *testing.T) {
 			t.Errorf("count = %d, want 1", count)
 		}
 	})
+
+	t.Run("enriched response fields", func(t *testing.T) {
+		result, err := getProjectDetails(ds, "Kubernetes")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Count    int `json:"count"`
+			Projects []struct {
+				Name         string            `json:"name"`
+				Description  string            `json:"description"`
+				HomepageURL  string            `json:"homepage_url"`
+				OSS          bool              `json:"oss"`
+				Repositories []Repository      `json:"repositories"`
+				Links        map[string]string `json:"links"`
+			} `json:"projects"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if resp.Count != 1 {
+			t.Fatalf("count = %d, want 1", resp.Count)
+		}
+		p := resp.Projects[0]
+		if p.Description == "" {
+			t.Error("expected non-empty description")
+		}
+		if p.HomepageURL != "https://kubernetes.io/" {
+			t.Errorf("homepage_url = %q, want %q", p.HomepageURL, "https://kubernetes.io/")
+		}
+		if !p.OSS {
+			t.Error("expected oss = true")
+		}
+		if len(p.Repositories) != 2 {
+			t.Errorf("repositories count = %d, want 2", len(p.Repositories))
+		}
+		if p.Links == nil {
+			t.Fatal("expected non-nil links")
+		}
+		if _, ok := p.Links["devstats"]; !ok {
+			t.Error("expected devstats link")
+		}
+		if _, ok := p.Links["blog"]; !ok {
+			t.Error("expected blog link")
+		}
+		if _, ok := p.Links["slack"]; !ok {
+			t.Error("expected slack link")
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/utilities/landscape-mcp-server/metrics_test.go
+++ b/utilities/landscape-mcp-server/metrics_test.go
@@ -1,0 +1,375 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// 3a: isMemberTier tests
+// ---------------------------------------------------------------------------
+
+func TestIsMemberTier(t *testing.T) {
+	tests := []struct {
+		name string
+		item LandscapeItem
+		tier string
+		want bool
+	}{
+		{
+			name: "Gold member via MemberSubcategory",
+			item: LandscapeItem{
+				Category:          "CNCF Members",
+				MemberSubcategory: "Gold",
+			},
+			tier: "Gold",
+			want: true,
+		},
+		{
+			name: "Silver member via Subcategory fallback",
+			item: LandscapeItem{
+				Category:    "CNCF Members",
+				Subcategory: "Silver",
+			},
+			tier: "Silver",
+			want: true,
+		},
+		{
+			name: "non-member category returns false",
+			item: LandscapeItem{
+				Category:    "Provisioning",
+				Subcategory: "Gold",
+			},
+			tier: "Gold",
+			want: false,
+		},
+		{
+			name: "case-insensitive MemberSubcategory",
+			item: LandscapeItem{
+				Category:          "CNCF Members",
+				MemberSubcategory: "gold",
+			},
+			tier: "Gold",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMemberTier(tt.item, tt.tier)
+			if got != tt.want {
+				t.Errorf("isMemberTier() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3b: queryProjects tests
+// ---------------------------------------------------------------------------
+
+func TestQueryProjects(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("no filters returns all projects", func(t *testing.T) {
+		result, err := queryProjects(ds, "", "", "", "", "", "", "", "", 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 3 {
+			t.Errorf("count = %d, want 3", count)
+		}
+	})
+
+	t.Run("filter by maturity graduated", func(t *testing.T) {
+		result, err := queryProjects(ds, "graduated", "", "", "", "", "", "", "", 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("filter by name case-insensitive substring", func(t *testing.T) {
+		result, err := queryProjects(ds, "", "kube", "", "", "", "", "", "", 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+		names := jsonProjectNames(t, result)
+		if len(names) == 0 || names[0] != "Kubernetes" {
+			t.Errorf("expected Kubernetes, got %v", names)
+		}
+	})
+
+	t.Run("filter by graduated date range", func(t *testing.T) {
+		result, err := queryProjects(ds, "", "", "2018-01-01", "2019-01-01", "", "", "", "", 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("limit constrains results", func(t *testing.T) {
+		result, err := queryProjects(ds, "", "", "", "", "", "", "", "", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("invalid date returns error", func(t *testing.T) {
+		_, err := queryProjects(ds, "", "", "bad-date", "", "", "", "", "", 100)
+		if err == nil {
+			t.Fatal("expected error for invalid date, got nil")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 3c: queryMembers tests
+// ---------------------------------------------------------------------------
+
+func TestQueryMembers(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("no filters returns all members", func(t *testing.T) {
+		result, err := queryMembers(ds, "", "", "", 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 3 {
+			t.Errorf("count = %d, want 3", count)
+		}
+	})
+
+	t.Run("filter by tier Gold", func(t *testing.T) {
+		result, err := queryMembers(ds, "Gold", "", "", 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("filter by joined_from", func(t *testing.T) {
+		result, err := queryMembers(ds, "", "2026-01-01", "", 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("limit constrains results", func(t *testing.T) {
+		result, err := queryMembers(ds, "", "", "", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 3d: getProjectDetails tests
+// ---------------------------------------------------------------------------
+
+func TestGetProjectDetails(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("exact name match", func(t *testing.T) {
+		result, err := getProjectDetails(ds, "Kubernetes")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("nonexistent returns error", func(t *testing.T) {
+		_, err := getProjectDetails(ds, "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent project, got nil")
+		}
+	})
+
+	t.Run("case-insensitive lookup", func(t *testing.T) {
+		result, err := getProjectDetails(ds, "kubernetes")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 3e: executeMetric tests
+// ---------------------------------------------------------------------------
+
+func TestExecuteMetric(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("incubating_project_count", func(t *testing.T) {
+		result, err := executeMetric("incubating_project_count", ds, time.Now())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		value := jsonInt(t, result, "value")
+		// Fixture has 1 incubating project: OpenTelemetry
+		if value != 1 {
+			t.Errorf("value = %d, want 1", value)
+		}
+	})
+
+	t.Run("sandbox_projects_joined_this_year", func(t *testing.T) {
+		// Akri accepted_at = 2021-09-14
+		now := time.Date(2021, 6, 1, 0, 0, 0, 0, time.UTC)
+		result, err := executeMetric("sandbox_projects_joined_this_year", ds, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		value := jsonInt(t, result, "value")
+		if value != 1 {
+			t.Errorf("value = %d, want 1", value)
+		}
+	})
+
+	t.Run("projects_graduated_last_year", func(t *testing.T) {
+		// Kubernetes graduated_at = 2018-03-06, so now must be in 2019
+		now := time.Date(2019, 6, 1, 0, 0, 0, 0, time.UTC)
+		result, err := executeMetric("projects_graduated_last_year", ds, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		value := jsonInt(t, result, "value")
+		if value != 1 {
+			t.Errorf("value = %d, want 1", value)
+		}
+	})
+
+	t.Run("gold_members_joined_this_year", func(t *testing.T) {
+		// TestGoldCorp joined_at = 2026-01-15
+		now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+		result, err := executeMetric("gold_members_joined_this_year", ds, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		value := jsonInt(t, result, "value")
+		if value != 1 {
+			t.Errorf("value = %d, want 1", value)
+		}
+	})
+
+	t.Run("silver_members_joined_this_year", func(t *testing.T) {
+		// TestSilverInc joined_at = 2025-06-01
+		now := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+		result, err := executeMetric("silver_members_joined_this_year", ds, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		value := jsonInt(t, result, "value")
+		if value != 1 {
+			t.Errorf("value = %d, want 1", value)
+		}
+	})
+
+	t.Run("silver_members_raised_last_month", func(t *testing.T) {
+		// TestSilverInc funding: seed 2026-02-01
+		// Set now to March 2026 so last month = Feb 2026
+		now := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+		result, err := executeMetric("silver_members_raised_last_month", ds, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		value := jsonInt(t, result, "value")
+		if value != 1 {
+			t.Errorf("value = %d, want 1", value)
+		}
+	})
+
+	t.Run("gold_members_raised_this_year", func(t *testing.T) {
+		// TestGoldCorp funding: series_b 2026-01-10
+		now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+		result, err := executeMetric("gold_members_raised_this_year", ds, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		value := jsonInt(t, result, "value")
+		if value != 1 {
+			t.Errorf("value = %d, want 1", value)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers
+// ---------------------------------------------------------------------------
+
+// jsonInt parses a JSON string and returns the integer value at the given key.
+func jsonInt(t *testing.T, jsonStr, key string) int {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+	val, ok := m[key]
+	if !ok {
+		t.Fatalf("key %q not found in JSON", key)
+	}
+	// json.Unmarshal decodes numbers as float64
+	num, ok := val.(float64)
+	if !ok {
+		t.Fatalf("key %q is not a number: %T", key, val)
+	}
+	return int(num)
+}
+
+// jsonProjectNames extracts project names from queryProjects JSON output.
+func jsonProjectNames(t *testing.T, jsonStr string) []string {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+	projects, ok := m["projects"].([]interface{})
+	if !ok {
+		t.Fatalf("projects is not an array")
+	}
+	names := make([]string, 0, len(projects))
+	for _, p := range projects {
+		pm, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := pm["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}

--- a/utilities/landscape-mcp-server/metrics_test.go
+++ b/utilities/landscape-mcp-server/metrics_test.go
@@ -320,6 +320,135 @@ func TestGetProjectDetails(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// 3d2: getMemberDetails tests
+// ---------------------------------------------------------------------------
+
+func TestGetMemberDetails(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("exact name match", func(t *testing.T) {
+		result, err := getMemberDetails(ds, "TestGoldCorp")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("case-insensitive lookup", func(t *testing.T) {
+		result, err := getMemberDetails(ds, "testgoldcorp")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("substring match returns multiple", func(t *testing.T) {
+		// "Test" matches TestGoldCorp, TestSilverInc, TestPlatinum
+		result, err := getMemberDetails(ds, "Test")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		if count != 3 {
+			t.Errorf("count = %d, want 3", count)
+		}
+	})
+
+	t.Run("nonexistent returns error", func(t *testing.T) {
+		_, err := getMemberDetails(ds, "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent member, got nil")
+		}
+	})
+
+	t.Run("enriched response fields", func(t *testing.T) {
+		result, err := getMemberDetails(ds, "TestGoldCorp")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Count   int `json:"count"`
+			Members []struct {
+				Name              string            `json:"name"`
+				Category          string            `json:"category"`
+				Subcategory       string            `json:"subcategory"`
+				MemberSubcategory string            `json:"member_subcategory"`
+				JoinedAt          string            `json:"joined_at"`
+				Links             map[string]string `json:"links"`
+				Organization      *orgSummary       `json:"organization"`
+			} `json:"members"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if resp.Count != 1 {
+			t.Fatalf("count = %d, want 1", resp.Count)
+		}
+		m := resp.Members[0]
+		if m.Name != "TestGoldCorp" {
+			t.Errorf("name = %q, want %q", m.Name, "TestGoldCorp")
+		}
+		if m.Category != "CNCF Members" {
+			t.Errorf("category = %q, want %q", m.Category, "CNCF Members")
+		}
+		if m.MemberSubcategory != "Gold" {
+			t.Errorf("member_subcategory = %q, want %q", m.MemberSubcategory, "Gold")
+		}
+		if m.JoinedAt != "2026-01-15" {
+			t.Errorf("joined_at = %q, want %q", m.JoinedAt, "2026-01-15")
+		}
+		// Crunchbase org should be populated
+		if m.Organization == nil {
+			t.Fatal("expected non-nil organization")
+		}
+		if m.Organization.Description != "A leading cloud infrastructure company." {
+			t.Errorf("org description = %q", m.Organization.Description)
+		}
+		if m.Organization.City != "San Francisco" {
+			t.Errorf("org city = %q, want %q", m.Organization.City, "San Francisco")
+		}
+	})
+
+	t.Run("member without crunchbase has nil organization", func(t *testing.T) {
+		result, err := getMemberDetails(ds, "TestPlatinum")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Members []struct {
+				Name         string      `json:"name"`
+				Organization *orgSummary `json:"organization"`
+			} `json:"members"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if len(resp.Members) != 1 {
+			t.Fatalf("expected 1 member, got %d", len(resp.Members))
+		}
+		if resp.Members[0].Organization != nil {
+			t.Error("expected nil organization for member without crunchbase_url")
+		}
+	})
+
+	t.Run("does not match non-member items", func(t *testing.T) {
+		// "kube" matches Kubernetes (a project), not a member
+		_, err := getMemberDetails(ds, "Kubernetes")
+		if err == nil {
+			t.Fatal("expected error since Kubernetes is a project not a member")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // 3e: executeMetric tests
 // ---------------------------------------------------------------------------
 
@@ -414,6 +543,453 @@ func TestExecuteMetric(t *testing.T) {
 		value := jsonInt(t, result, "value")
 		if value != 1 {
 			t.Errorf("value = %d, want 1", value)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 5a: listCategories tests
+// ---------------------------------------------------------------------------
+
+func TestListCategories(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("returns all categories with subcategories", func(t *testing.T) {
+		result, err := listCategories(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Categories []struct {
+				Name          string `json:"name"`
+				ItemCount     int    `json:"item_count"`
+				Subcategories []struct {
+					Name      string `json:"name"`
+					ItemCount int    `json:"item_count"`
+				} `json:"subcategories"`
+			} `json:"categories"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// Fixture has 4 categories: CNCF Members, Observability and Analysis, Orchestration & Management, Provisioning
+		if len(resp.Categories) != 4 {
+			t.Errorf("categories count = %d, want 4", len(resp.Categories))
+		}
+
+		// Find CNCF Members category
+		var membersCat *struct {
+			Name          string `json:"name"`
+			ItemCount     int    `json:"item_count"`
+			Subcategories []struct {
+				Name      string `json:"name"`
+				ItemCount int    `json:"item_count"`
+			} `json:"subcategories"`
+		}
+		for i := range resp.Categories {
+			if resp.Categories[i].Name == "CNCF Members" {
+				membersCat = &resp.Categories[i]
+				break
+			}
+		}
+		if membersCat == nil {
+			t.Fatal("CNCF Members category not found")
+		}
+		if membersCat.ItemCount != 3 {
+			t.Errorf("CNCF Members item_count = %d, want 3", membersCat.ItemCount)
+		}
+		// Should have 3 subcategories: Gold, Silver, Platinum
+		if len(membersCat.Subcategories) != 3 {
+			t.Errorf("CNCF Members subcategories count = %d, want 3", len(membersCat.Subcategories))
+		}
+	})
+
+	t.Run("categories are sorted alphabetically", func(t *testing.T) {
+		result, err := listCategories(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Categories []struct {
+				Name string `json:"name"`
+			} `json:"categories"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		for i := 1; i < len(resp.Categories); i++ {
+			if resp.Categories[i].Name < resp.Categories[i-1].Name {
+				t.Errorf("categories not sorted: %q before %q", resp.Categories[i-1].Name, resp.Categories[i].Name)
+			}
+		}
+	})
+
+	t.Run("item counts are correct per subcategory", func(t *testing.T) {
+		result, err := listCategories(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Categories []struct {
+				Name          string `json:"name"`
+				ItemCount     int    `json:"item_count"`
+				Subcategories []struct {
+					Name      string `json:"name"`
+					ItemCount int    `json:"item_count"`
+				} `json:"subcategories"`
+			} `json:"categories"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// Find Orchestration & Management → Scheduling & Orchestration → 1 (Kubernetes)
+		for _, cat := range resp.Categories {
+			if cat.Name == "Orchestration & Management" {
+				if cat.ItemCount != 1 {
+					t.Errorf("Orchestration & Management item_count = %d, want 1", cat.ItemCount)
+				}
+				if len(cat.Subcategories) != 1 {
+					t.Errorf("Orchestration & Management subcategories = %d, want 1", len(cat.Subcategories))
+				}
+				if cat.Subcategories[0].Name != "Scheduling & Orchestration" {
+					t.Errorf("subcategory name = %q, want %q", cat.Subcategories[0].Name, "Scheduling & Orchestration")
+				}
+				if cat.Subcategories[0].ItemCount != 1 {
+					t.Errorf("Scheduling & Orchestration item_count = %d, want 1", cat.Subcategories[0].ItemCount)
+				}
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 5b: landscapeSummary tests
+// ---------------------------------------------------------------------------
+
+func TestLandscapeSummary(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("returns correct total counts", func(t *testing.T) {
+		result, err := landscapeSummary(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		totalItems := jsonInt(t, result, "total_items")
+		if totalItems != 6 {
+			t.Errorf("total_items = %d, want 6", totalItems)
+		}
+
+		totalProjects := jsonInt(t, result, "total_projects")
+		if totalProjects != 3 {
+			t.Errorf("total_projects = %d, want 3", totalProjects)
+		}
+
+		totalMembers := jsonInt(t, result, "total_members")
+		if totalMembers != 3 {
+			t.Errorf("total_members = %d, want 3", totalMembers)
+		}
+
+		categoriesCount := jsonInt(t, result, "categories_count")
+		if categoriesCount != 4 {
+			t.Errorf("categories_count = %d, want 4", categoriesCount)
+		}
+	})
+
+	t.Run("projects_by_maturity breakdown", func(t *testing.T) {
+		result, err := landscapeSummary(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			ProjectsByMaturity map[string]int `json:"projects_by_maturity"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.ProjectsByMaturity["graduated"] != 1 {
+			t.Errorf("graduated = %d, want 1", resp.ProjectsByMaturity["graduated"])
+		}
+		if resp.ProjectsByMaturity["incubating"] != 1 {
+			t.Errorf("incubating = %d, want 1", resp.ProjectsByMaturity["incubating"])
+		}
+		if resp.ProjectsByMaturity["sandbox"] != 1 {
+			t.Errorf("sandbox = %d, want 1", resp.ProjectsByMaturity["sandbox"])
+		}
+	})
+
+	t.Run("members_by_tier breakdown", func(t *testing.T) {
+		result, err := landscapeSummary(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			MembersByTier map[string]int `json:"members_by_tier"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if resp.MembersByTier["Gold"] != 1 {
+			t.Errorf("Gold = %d, want 1", resp.MembersByTier["Gold"])
+		}
+		if resp.MembersByTier["Silver"] != 1 {
+			t.Errorf("Silver = %d, want 1", resp.MembersByTier["Silver"])
+		}
+		if resp.MembersByTier["Platinum"] != 1 {
+			t.Errorf("Platinum = %d, want 1", resp.MembersByTier["Platinum"])
+		}
+	})
+
+	t.Run("items_with_crunchbase_data count", func(t *testing.T) {
+		result, err := landscapeSummary(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cbCount := jsonInt(t, result, "items_with_crunchbase_data")
+		// TestGoldCorp and TestSilverInc have crunchbase data
+		if cbCount != 2 {
+			t.Errorf("items_with_crunchbase_data = %d, want 2", cbCount)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 5c: searchLandscape tests
+// ---------------------------------------------------------------------------
+
+func TestSearchLandscape(t *testing.T) {
+	ds := loadTestDataset(t)
+
+	t.Run("search by name", func(t *testing.T) {
+		result, err := searchLandscape(ds, "kubernetes", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Count int `json:"count"`
+			Items []struct {
+				Name        string   `json:"name"`
+				MatchFields []string `json:"match_fields"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if resp.Count != 1 {
+			t.Errorf("count = %d, want 1", resp.Count)
+		}
+		if resp.Items[0].Name != "Kubernetes" {
+			t.Errorf("name = %q, want %q", resp.Items[0].Name, "Kubernetes")
+		}
+		// Should match on "name"
+		found := false
+		for _, f := range resp.Items[0].MatchFields {
+			if f == "name" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected match_fields to contain 'name', got %v", resp.Items[0].MatchFields)
+		}
+	})
+
+	t.Run("search by description", func(t *testing.T) {
+		result, err := searchLandscape(ds, "containerized", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("search by category", func(t *testing.T) {
+		result, err := searchLandscape(ds, "Provisioning", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Count int `json:"count"`
+			Items []struct {
+				Name        string   `json:"name"`
+				MatchFields []string `json:"match_fields"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if resp.Count != 1 {
+			t.Errorf("count = %d, want 1", resp.Count)
+		}
+		if resp.Items[0].Name != "Akri" {
+			t.Errorf("name = %q, want %q", resp.Items[0].Name, "Akri")
+		}
+	})
+
+	t.Run("search by subcategory", func(t *testing.T) {
+		result, err := searchLandscape(ds, "Monitoring", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("search by homepage_url", func(t *testing.T) {
+		result, err := searchLandscape(ds, "kubernetes.io", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("case-insensitive search", func(t *testing.T) {
+		result, err := searchLandscape(ds, "KUBERNETES", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		count := jsonInt(t, result, "count")
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+	})
+
+	t.Run("limit constrains results", func(t *testing.T) {
+		// "Test" matches 3 members
+		result, err := searchLandscape(ds, "Test", 2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		count := jsonInt(t, result, "count")
+		if count != 2 {
+			t.Errorf("count = %d, want 2", count)
+		}
+	})
+
+	t.Run("no matches returns empty", func(t *testing.T) {
+		result, err := searchLandscape(ds, "zzzznonexistent", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		count := jsonInt(t, result, "count")
+		if count != 0 {
+			t.Errorf("count = %d, want 0", count)
+		}
+	})
+
+	t.Run("empty query returns error", func(t *testing.T) {
+		_, err := searchLandscape(ds, "", 20)
+		if err == nil {
+			t.Fatal("expected error for empty query")
+		}
+	})
+
+	t.Run("result includes maturity for projects", func(t *testing.T) {
+		result, err := searchLandscape(ds, "kubernetes", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Items []struct {
+				Maturity string `json:"maturity"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if len(resp.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(resp.Items))
+		}
+		if resp.Items[0].Maturity != "graduated" {
+			t.Errorf("maturity = %q, want %q", resp.Items[0].Maturity, "graduated")
+		}
+	})
+
+	t.Run("result includes member_subcategory for members", func(t *testing.T) {
+		result, err := searchLandscape(ds, "TestGoldCorp", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Items []struct {
+				MemberSubcategory string `json:"member_subcategory"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if len(resp.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(resp.Items))
+		}
+		if resp.Items[0].MemberSubcategory != "Gold" {
+			t.Errorf("member_subcategory = %q, want %q", resp.Items[0].MemberSubcategory, "Gold")
+		}
+	})
+
+	t.Run("default limit is 20 and max is 100", func(t *testing.T) {
+		// With limit 0, should use default 20
+		result, err := searchLandscape(ds, "Test", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := jsonInt(t, result, "count")
+		// only 3 items match "Test", so all 3 returned within default limit
+		if count != 3 {
+			t.Errorf("count = %d, want 3", count)
+		}
+	})
+
+	t.Run("multiple match_fields", func(t *testing.T) {
+		// "kubernetes.io" appears in homepage_url and name doesn't match it
+		// But "kubernetes" appears in name, description etc.
+		result, err := searchLandscape(ds, "kubernetes", 20)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var resp struct {
+			Items []struct {
+				Name        string   `json:"name"`
+				MatchFields []string `json:"match_fields"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if len(resp.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(resp.Items))
+		}
+		// "kubernetes" matches name, homepage_url ("kubernetes.io")
+		fields := resp.Items[0].MatchFields
+		if len(fields) < 2 {
+			t.Errorf("expected at least 2 match_fields, got %v", fields)
 		}
 	})
 }

--- a/utilities/landscape-mcp-server/testdata/sample.json
+++ b/utilities/landscape-mcp-server/testdata/sample.json
@@ -2,12 +2,31 @@
   "items": [
     {
       "name": "Kubernetes",
+      "id": "kubernetes",
+      "description": "An open-source system for automating deployment, scaling, and management of containerized applications.",
+      "homepage_url": "https://kubernetes.io/",
       "category": "Orchestration & Management",
       "subcategory": "Scheduling & Orchestration",
       "maturity": "graduated",
       "accepted_at": "2016-03-10",
       "incubating_at": "2016-03-10",
-      "graduated_at": "2018-03-06"
+      "graduated_at": "2018-03-06",
+      "oss": true,
+      "devstats_url": "https://k8s.devstats.cncf.io/",
+      "blog_url": "https://kubernetes.io/blog/",
+      "twitter_url": "https://twitter.com/kuabornetesio",
+      "slack_url": "https://slack.k8s.io/",
+      "chat_channel": "#kubernetes-users",
+      "repositories": [
+        {
+          "url": "https://github.com/kubernetes/kubernetes",
+          "primary": true
+        },
+        {
+          "url": "https://github.com/kubernetes/website",
+          "primary": false
+        }
+      ]
     },
     {
       "name": "OpenTelemetry",
@@ -22,7 +41,18 @@
       "category": "Provisioning",
       "subcategory": "Automation & Configuration",
       "maturity": "sandbox",
-      "accepted_at": "2021-09-14"
+      "accepted_at": "2021-09-14",
+      "audits": [
+        {
+          "date": "2023-06-15",
+          "type": "security",
+          "url": "https://example.com/akri-audit-report",
+          "vendor": "Trail of Bits"
+        }
+      ],
+      "summary": {
+        "use_case": "Akri lets you automatically discover and use leaf devices (such as IP cameras and USB devices)."
+      }
     },
     {
       "name": "TestGoldCorp",
@@ -50,6 +80,17 @@
   ],
   "crunchbase_data": {
     "https://www.crunchbase.com/organization/testgoldcorp": {
+      "name": "TestGoldCorp",
+      "description": "A leading cloud infrastructure company.",
+      "city": "San Francisco",
+      "country": "United States",
+      "region": "North America",
+      "company_type": "for_profit",
+      "num_employees_min": 501,
+      "num_employees_max": 1000,
+      "categories": ["Cloud Infrastructure", "Enterprise Software"],
+      "linkedin_url": "https://www.linkedin.com/company/testgoldcorp",
+      "twitter_url": "https://twitter.com/testgoldcorp",
       "funding_rounds": [
         {
           "amount": 50000000,
@@ -60,6 +101,12 @@
           "amount": 20000000,
           "announced_on": "2025-06-15",
           "kind": "series_a"
+        }
+      ],
+      "acquisitions": [
+        {
+          "acquiree_name": "SmallStartup",
+          "announced_on": "2025-03-20"
         }
       ]
     },

--- a/utilities/landscape-mcp-server/testdata/sample.json
+++ b/utilities/landscape-mcp-server/testdata/sample.json
@@ -1,0 +1,76 @@
+{
+  "items": [
+    {
+      "name": "Kubernetes",
+      "category": "Orchestration & Management",
+      "subcategory": "Scheduling & Orchestration",
+      "maturity": "graduated",
+      "accepted_at": "2016-03-10",
+      "incubating_at": "2016-03-10",
+      "graduated_at": "2018-03-06"
+    },
+    {
+      "name": "OpenTelemetry",
+      "category": "Observability and Analysis",
+      "subcategory": "Monitoring",
+      "maturity": "incubating",
+      "accepted_at": "2019-05-07",
+      "incubating_at": "2021-08-26"
+    },
+    {
+      "name": "Akri",
+      "category": "Provisioning",
+      "subcategory": "Automation & Configuration",
+      "maturity": "sandbox",
+      "accepted_at": "2021-09-14"
+    },
+    {
+      "name": "TestGoldCorp",
+      "category": "CNCF Members",
+      "subcategory": "Gold",
+      "member_subcategory": "Gold",
+      "joined_at": "2026-01-15",
+      "crunchbase_url": "https://www.crunchbase.com/organization/testgoldcorp"
+    },
+    {
+      "name": "TestSilverInc",
+      "category": "CNCF Members",
+      "subcategory": "Silver",
+      "member_subcategory": "Silver",
+      "joined_at": "2025-06-01",
+      "crunchbase_url": "https://www.crunchbase.com/organization/testsilverinc"
+    },
+    {
+      "name": "TestPlatinum",
+      "category": "CNCF Members",
+      "subcategory": "Platinum",
+      "member_subcategory": "Platinum",
+      "joined_at": "2020-01-01"
+    }
+  ],
+  "crunchbase_data": {
+    "https://www.crunchbase.com/organization/testgoldcorp": {
+      "funding_rounds": [
+        {
+          "amount": 50000000,
+          "announced_on": "2026-01-10",
+          "kind": "series_b"
+        },
+        {
+          "amount": 20000000,
+          "announced_on": "2025-06-15",
+          "kind": "series_a"
+        }
+      ]
+    },
+    "https://www.crunchbase.com/organization/testsilverinc": {
+      "funding_rounds": [
+        {
+          "amount": 10000000,
+          "announced_on": "2026-02-01",
+          "kind": "seed"
+        }
+      ]
+    }
+  }
+}

--- a/utilities/landscape-mcp-server/testutil_test.go
+++ b/utilities/landscape-mcp-server/testutil_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// loadTestDataset loads the test fixture from testdata/sample.json.
+func loadTestDataset(t *testing.T) *Dataset {
+	t.Helper()
+	ds, err := loadDataset(context.Background(), dataSource{
+		filePath: "testdata/sample.json",
+	})
+	if err != nil {
+		t.Fatalf("failed to load test dataset: %v", err)
+	}
+	return ds
+}
+
+// timePtr parses a "2006-01-02" date string and returns a *time.Time, or panics.
+func timePtr(s string) *time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic("timePtr: " + err.Error())
+	}
+	return &t
+}
+
+// int64Ptr returns a pointer to the given int64 value.
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+// makeItem creates a LandscapeItem with the given name and maturity, applying optional modifiers.
+func makeItem(name, maturity string, opts ...func(*LandscapeItem)) LandscapeItem {
+	item := LandscapeItem{
+		Name:     name,
+		Maturity: maturity,
+	}
+	for _, opt := range opts {
+		opt(&item)
+	}
+	return item
+}
+
+func TestLoadTestDataset(t *testing.T) {
+	ds := loadTestDataset(t)
+	if len(ds.Items) != 6 {
+		t.Errorf("expected 6 items, got %d", len(ds.Items))
+	}
+	if len(ds.CrunchbaseOrgs) != 2 {
+		t.Errorf("expected 2 crunchbase orgs, got %d", len(ds.CrunchbaseOrgs))
+	}
+}

--- a/utilities/landscape-mcp-server/types.go
+++ b/utilities/landscape-mcp-server/types.go
@@ -8,25 +8,109 @@ type Dataset struct {
 	CrunchbaseOrgs map[string]CrunchbaseOrganization
 }
 
-// LandscapeItem captures a single entry in the landscape with the
-// fields required for the MCP queries we support.
+// LandscapeItem captures a single entry in the landscape.
 type LandscapeItem struct {
-	Name              string
-	Category          string
-	Subcategory       string
-	MemberSubcategory string
-	Maturity          string
-	JoinedAt          *time.Time
-	AcceptedAt        *time.Time
-	GraduatedAt       *time.Time
-	IncubatingAt      *time.Time
-	CrunchbaseURL     string
+	// Identity
+	Name        string
+	ID          string
+	Description string
+	HomepageURL string
+	LogoURL     string
+
+	// Taxonomy
+	Category             string
+	Subcategory          string
+	MemberSubcategory    string
+	Maturity             string
+	AdditionalCategories []ItemCategory
+
+	// Dates
+	JoinedAt     *time.Time
+	AcceptedAt   *time.Time
+	GraduatedAt  *time.Time
+	IncubatingAt *time.Time
+	ArchivedAt   *time.Time
+
+	// Project metadata
+	OSS                   bool
+	Specification         bool
+	EndUser               bool
+	ParentProject         string
+	LatestAnnualReviewAt  *time.Time
+	LatestAnnualReviewURL string
+	Summary               *ItemSummary
+	Audits                []Audit
+
+	// Links
+	CrunchbaseURL        string
+	DevStatsURL          string
+	ArtworkURL           string
+	BlogURL              string
+	TwitterURL           string
+	SlackURL             string
+	DiscordURL           string
+	YouTubeURL           string
+	LinkedInURL          string
+	StackOverflowURL     string
+	ChatChannel          string
+	MailingListURL       string
+	DocumentationURL     string
+	GithubDiscussionsURL string
+
+	// Repositories
+	Repositories []Repository
 }
 
-// CrunchbaseOrganization describes the subset of Crunchbase data the
-// server needs to compute funding-based queries.
+// ItemCategory represents an additional category assignment.
+type ItemCategory struct {
+	Category    string
+	Subcategory string
+}
+
+// ItemSummary holds a project's summary information.
+type ItemSummary struct {
+	UseCase string
+}
+
+// Audit represents a security or other audit of a project.
+type Audit struct {
+	Date   *time.Time
+	Type   string
+	URL    string
+	Vendor string
+}
+
+// Repository represents a source code repository.
+type Repository struct {
+	URL     string
+	Primary bool
+}
+
+// CrunchbaseOrganization describes Crunchbase data for an organization.
 type CrunchbaseOrganization struct {
-	FundingRounds []FundingRound
+	Name            string
+	Description     string
+	HomepageURL     string
+	City            string
+	Country         string
+	Region          string
+	CompanyType     string // "for_profit", "non_profit"
+	NumEmployeesMin int
+	NumEmployeesMax int
+	Categories      []string
+	TotalFunding    *int64
+	FundingRounds   []FundingRound
+	Acquisitions    []Acquisition
+	LinkedInURL     string
+	TwitterURL      string
+	StockExchange   string
+	Ticker          string
+}
+
+// Acquisition represents a company acquisition.
+type Acquisition struct {
+	AcquireeName string
+	AnnouncedOn  *time.Time
 }
 
 // FundingRound captures a single funding event.


### PR DESCRIPTION
## Summary

Transforms the landscape MCP server from a narrow CNCF-specific POC into a comprehensive, configurable, well-tested MCP server that exposes the full richness of any Landscape dataset.

- **12 tools** (up from 4): enhanced query/detail tools + new discovery, analytical, and search tools
- **MCP Resources & Prompts**: first-class support for `resources/list`, `resources/read`, `prompts/list`, `prompts/get`
- **Landscape-agnostic**: configurable `LandscapeConfig` drives all descriptions — not hardcoded to CNCF
- **Rich data model**: loads all available Landscape + Crunchbase fields (repos, funding, orgs, locations)
- **29 passing tests** across 5 test files with shared fixture data
- **Zero external dependencies**: Go 1.21 standard library only

## Tools

| Tool | Status | Description |
|------|--------|-------------|
| `query_projects` | Enhanced | Added category, subcategory filters + pagination offset |
| `query_members` | Enhanced | Added category filter + pagination offset |
| `get_project_details` | Enhanced | Full data: repos, links, org summary, funding, extra fields |
| `get_member_details` | New | Detail view for member organizations |
| `list_categories` | New | Enumerate all categories with subcategories and item counts |
| `landscape_summary` | New | High-level landscape statistics |
| `search_landscape` | New | Full-text search across names, descriptions, URLs |
| `compare_projects` | New | Side-by-side project comparison |
| `funding_analysis` | New | Crunchbase funding aggregation by tier/year |
| `geographic_distribution` | New | Member location breakdown by country/region/city |
| `project_metrics` | Unchanged | — |
| `membership_metrics` | Unchanged | — |

## MCP Capabilities

- **Resources**: `landscape://categories`, `landscape://summary`
- **Prompts**: `analyze_landscape`, `compare_projects`
- **Lifecycle**: `initialize` reports server version + capabilities; `notifications/dataset_refreshed` triggers hot reload

## Changes

11 files changed, +4,411 / -167 lines (all scoped to `utilities/landscape-mcp-server/`)

## Testing

```
$ go test ./... -count=1
ok  github.com/cncf/landscape2/go/mcp-server  0.014s
```