### PR TITLE
Ability to create runner VMs on Ashburn

### DIFF
--- a/.github/workflows/publish-cloudrunner-images.yml
+++ b/.github/workflows/publish-cloudrunner-images.yml
@@ -143,3 +143,69 @@ jobs:
             --type slsaprovenance "${{ env.IMAGE_NAME }}@${{env.IMAGE_DIGEST}}"
       # TODO (github.com/slsa-framework/slsa-verifier/issues/92):
       #       Add step to verify using slsa-verifier
+
+  # Test the published image by running it and see if the VM is created.
+  test-image:
+    needs: build-cloudrunner-images
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["amd64", "arm64", "gpu-a10-1", "gpu-a10-2"]
+        include:
+          - runner: "amd64"
+            arch: "amd64"
+            shape: "VM.Standard.E6.Flex"
+            ocpus: 2
+            memory: 8.0
+            region: "us-sanjose-1"
+            availability-domain: bzBe:US-SANJOSE-1-AD-1
+            subnet-id: ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
+          - runner: "arm64"
+            arch: "arm64"
+            shape: "VM.Standard.A1.Flex"
+            ocpus: 2
+            memory: 8.0
+            region: "us-sanjose-1"
+            availability-domain: bzBe:US-SANJOSE-1-AD-1
+            subnet-id: ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
+          - runner: "gpu-a10-1"
+            arch: "amd64"
+            shape: "VM.GPU.A10.1"
+            ocpus: 0   # Not a flex type, so ocpus and memory are determined by the shape
+            memory: 0  # Not a flex type, so ocpus and memory are determined by the shape
+            region: "us-sanjose-1"
+            availability-domain: bzBe:US-SANJOSE-1-AD-1
+            subnet-id: ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
+          - runner: "gpu-a10-2"
+            arch: "amd64"
+            shape: "VM.GPU.A10.2"
+            ocpus: 0   # Not a flex type, so ocpus and memory are determined by the shape
+            memory: 0  # Not a flex type, so ocpus and memory are determined by the shape
+            region: "us-ashburn-1"
+            availability-domain: bzBe:US-ASHBURN-AD-2
+            subnet-id: ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
+    steps:
+      - name: Test the published Cloudrunner Docker image
+        run: |
+          docker run \
+            -e OCI_CLI_USER=${{ env.OCI_CLI_USER }} \
+            -e OCI_CLI_TENANCY=${{ env.OCI_CLI_TENANCY }} \
+            -e OCI_CLI_FINGERPRINT=${{ env.OCI_CLI_FINGERPRINT }} \
+            -e OCI_CLI_KEY_CONTENT=${{ env.OCI_CLI_KEY_CONTENT }} \
+            -e OCI_CLI_REGION=${{ env.OCI_CLI_REGION }} \
+            ${{ needs.build-cloudrunner-images.outputs.image }} \
+            --arch=${{ matrix.arch }} \
+            --shape=${{ matrix.shape }} \
+            --shape-ocpus=${{ matrix.ocpus }} \
+            --shape-memory-in-gbs=${{ matrix.memory }} \
+            --region=${{ matrix.region}} \
+            --availability-domain=${{ matrix.availability-domain }} \
+            --subnet-id=${{ matrix.subnet-id }}

--- a/.github/workflows/publish-cloudrunner-images.yml
+++ b/.github/workflows/publish-cloudrunner-images.yml
@@ -202,7 +202,7 @@ jobs:
           key_file=${OCI_KEY_FILE}
           EOF
 
-          echo "${{ secrets.OCI_CLI_KEY_CONTENT }}" | base64 -d > ${OCI_KEY_FILE}
+          echo "${{ secrets.OCI_CLI_KEY_CONTENT }}" > ${OCI_KEY_FILE}
 
           docker run -v ${{ github.workspace}}/.oci:/root/.oci \
             ${{ needs.build-cloudrunner-images.outputs.image }} \

--- a/.github/workflows/publish-cloudrunner-images.yml
+++ b/.github/workflows/publish-cloudrunner-images.yml
@@ -149,12 +149,6 @@ jobs:
     needs: build-cloudrunner-images
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
-      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
-      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
-      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
-      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
     strategy:
       fail-fast: false
       matrix:
@@ -195,12 +189,22 @@ jobs:
     steps:
       - name: Test the published Cloudrunner Docker image
         run: |
-          docker run \
-            -e OCI_CLI_USER=${{ env.OCI_CLI_USER }} \
-            -e OCI_CLI_TENANCY=${{ env.OCI_CLI_TENANCY }} \
-            -e OCI_CLI_FINGERPRINT=${{ env.OCI_CLI_FINGERPRINT }} \
-            -e OCI_CLI_KEY_CONTENT=${{ env.OCI_CLI_KEY_CONTENT }} \
-            -e OCI_CLI_REGION=${{ env.OCI_CLI_REGION }} \
+          OCI_CONFIG_FILE="${{ github.workspace}}/.oci/config"
+          OCI_KEY_FILE="${{ github.workspace}}/.oci/oci_api_key.pem"
+          mkdir -p "${{ github.workspace}}/.oci"
+
+          cat > ${OCI_CONFIG_FILE} << EOF
+          [DEFAULT]
+          user=${{ secrets.OCI_CLI_USER }}
+          fingerprint=${{ secrets.OCI_CLI_FINGERPRINT }}
+          tenancy=${{ secrets.OCI_CLI_TENANCY }}
+          region=${{ secrets.OCI_CLI_REGION }}
+          key_file=${OCI_KEY_FILE}
+          EOF
+
+          echo "${{ secrets.OCI_CLI_KEY_CONTENT }}" | base64 -d > ${OCI_KEY_FILE}
+
+          docker run -v ${{ github.workspace}}/.oci:/root/.oci \
             ${{ needs.build-cloudrunner-images.outputs.image }} \
             --arch=${{ matrix.arch }} \
             --shape=${{ matrix.shape }} \

--- a/.github/workflows/publish-cloudrunner-images.yml
+++ b/.github/workflows/publish-cloudrunner-images.yml
@@ -146,6 +146,7 @@ jobs:
 
   # Test the published image by running it and see if the VM is created.
   test-image:
+    if: ${{ github.event_name != 'pull_request' }}
     needs: build-cloudrunner-images
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -205,7 +206,7 @@ jobs:
           echo "${{ secrets.OCI_CLI_KEY_CONTENT }}" > ${OCI_KEY_FILE}
 
           docker run -v ${{ github.workspace}}/.oci:/root/.oci \
-            ${{ needs.build-cloudrunner-images.outputs.image }} \
+            ${{ needs.build-cloudrunner-images.outputs.image }}@${{ needs.build-cloudrunner-images.outputs.digest }} \
             --arch=${{ matrix.arch }} \
             --shape=${{ matrix.shape }} \
             --shape-ocpus=${{ matrix.ocpus }} \

--- a/.github/workflows/test-vm-runner.yaml
+++ b/.github/workflows/test-vm-runner.yaml
@@ -1,10 +1,10 @@
-name: Test VM Runner
+name: Test VM Runners
 
 on:
   workflow_dispatch:
     inputs:
       test_gpu:
-        description: 'Test GPU Runner'
+        description: 'Test GPU Runners'
         required: false
         type: choice
         options:
@@ -51,9 +51,26 @@ jobs:
       - name: Run kind cluster
         run: ${{ github.workspace }}/.github/scripts/test_with_kind_cluster.sh
 
-  test-gpu-runner:
+  test-a10-1-gpu-runner:
     runs-on:
       labels: oracle-vm-gpu-a10-1
+      group: GPUs
+    if: ${{ github.event.inputs.test_gpu == 'yes' }}
+    steps:
+      - name: checkout gpus
+        run: |
+          echo "[*] Detailed GPU query"
+          nvidia-smi -q
+
+          echo "[*] Specific information"
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv
+
+          echo "[*] NVIDIA driver version"
+          cat /proc/driver/nvidia/version
+
+  test-a10-2-gpu-runner:
+    runs-on:
+      labels: oracle-vm-gpu-a10-2
       group: GPUs
     if: ${{ github.event.inputs.test_gpu == 'yes' }}
     steps:

--- a/ci/cloudrunners/oci/main.go
+++ b/ci/cloudrunners/oci/main.go
@@ -25,6 +25,7 @@ var args struct {
 	debug bool
 
 	arch               string
+	region             string
 	compartmentId      string
 	subnetId           string
 	availabilityDomain string
@@ -56,6 +57,9 @@ func run(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create network client: %w", err)
 	}
+
+	computeClient.SetRegion(args.region)
+	networkClient.SetRegion(args.region)
 
 	// List Images and retrieve the latest ID by type and arch
 
@@ -206,6 +210,12 @@ func init() {
 		"arch",
 		"x86",
 		"Machine architecture",
+	)
+	flags.StringVar(
+		&args.region,
+		"region",
+		"us-sanjose-1",
+		"OCI region",
 	)
 	flags.StringVar(
 		&args.availabilityDomain,


### PR DESCRIPTION
This PR:

- Adds a test to create different types of VMs with the new cloudrunner image
- Adds ability to create VMs in another region (Currently, only `us-ashburn-1` is supported)
- Manual VM runner test is extended to test both A10.1 and A10.2 shapes.

There are a couple of requirements to create runner VMs in another region:

1. The OS image must be uploaded to a bucket in that region:
> This was solved by creating a replication between the current bucket on us-sanjose-1 and us-ashburn-1. So, all new objects on the bucket will be replicated to Ashburn automagically.

2. This OS image must be imported as a Custom Image:
> Latest image was manually imported. The pipeline will be updated to import new ones.