### PR TITLE
Enhance CNCF Project Status Audit with LFX Insights Health Metrics

### DIFF
--- a/.github/workflows/sync-lfx-insights-health.yml
+++ b/.github/workflows/sync-lfx-insights-health.yml
@@ -1,0 +1,67 @@
+name: Sync LFX Insights health scores
+
+on:
+  schedule:
+    # Weekly, Sunday 07:00 UTC (low traffic); no LFX_TOKEN required
+    - cron: "0 7 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests pyyaml
+
+      - name: Generate lfx_insights_health.yaml
+        run: |
+          test -f datasources/pcc_projects.yaml || (
+            echo "datasources/pcc_projects.yaml is missing. Run Sync PCC workflow first or merge a branch that includes it." >&2
+            exit 1
+          )
+          python scripts/fetch_lfx_insights_health.py
+        working-directory: ./utilities/audit_project_lifecycle_across_tools
+
+      - name: Clean up git credentials
+        run: |
+          git config --local  --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all http.https://github.com/.extraheader || true
+          git config --local  --unset-all http.extraheader || true
+          git config --global --unset-all http.extraheader || true
+          git config --local  --unset-all url."https://github.com/".insteadOf || true
+          git config --global --unset-all url."https://github.com/".insteadOf || true
+          git remote set-url origin https://github.com/${{ github.repository }}.git
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          signoff: true
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          commit-message: "Update LFX Insights health snapshot"
+          title: "Update LFX Insights health snapshot"
+          body: |
+            Weekly snapshot of [LFX Insights](https://insights.linuxfoundation.org/) data for projects listed in `pcc_projects.yaml`.
+
+            - Output: `utilities/audit_project_lifecycle_across_tools/datasources/lfx_insights_health.yaml` (`health_tier` → **Insights Health** column, `overall_score` → **Health Score** column in the audit tables)
+            - No `LFX_TOKEN` (public badge + project page)
+          branch: automation/lfx-insights-health
+          add-paths: |
+            utilities/audit_project_lifecycle_across_tools/datasources/lfx_insights_health.yaml

--- a/.github/workflows/sync-pcc-and-audit-statuses.yml
+++ b/.github/workflows/sync-pcc-and-audit-statuses.yml
@@ -87,6 +87,7 @@ jobs:
             - Foundation Maintainers CSV
             - DevStats
             - Artwork README
+            - [LFX Insights](https://insights.linuxfoundation.org/) **Insights Health** tier and numeric **Health Score** (from `datasources/lfx_insights_health.yaml` when present; weekly workflow can populate it)
           branch: automation/update-pcc-projects
           add-paths: |
             utilities/audit_project_lifecycle_across_tools/datasources/pcc_projects.yaml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Tools and scripts for managing self-hosted GitHub Actions runners on CNCF's infr
 
 For more information, see the [CI documentation](./ci/README.md).
 
-### [Additional Tools - Add other major tools here]
+### Project Status Audit
+
+Cross-checks CNCF project lifecycle data from **LFX PCC** against Landscape, CLOMonitor, maintainers CSV, DevStats, and Artwork, and optionally adds **[LFX Insights](https://insights.linuxfoundation.org/)** **Insights Health** (tier) and **Health Score** (number) when `lfx_insights_health.yaml` is present (informational only; not used for anomaly detection).
+
+See [utilities/audit_project_lifecycle_across_tools/README.md](./utilities/audit_project_lifecycle_across_tools/README.md) for workflows, local usage, and file layout.
 
 ## Contributing
 

--- a/utilities/audit_project_lifecycle_across_tools/README.md
+++ b/utilities/audit_project_lifecycle_across_tools/README.md
@@ -1,90 +1,98 @@
 # Project Status Audit
-Project Status Audit
 
-This repository generates a canonical list of CNCF project statuses from the LFX PCC API and audits that source of truth against multiple public datasets (CNCF Landscape, CLOMonitor, Foundation Maintainers CSV, and DevStats). Results are published as a unified human-readable table.
+This utility generates a canonical list of CNCF project statuses from the LFX PCC API and audits that source of truth against multiple public datasets (CNCF Landscape, CLOMonitor, Foundation Maintainers CSV, DevStats, Artwork) plus optional [LFX Insights](https://insights.linuxfoundation.org/) health metrics. Results are published as unified human-readable tables.
 
 ## What it does
 
-- Fetches PCC projects from LFX and writes `pcc_projects.yaml` (source of truth)
-  - Includes active CNCF projects grouped by category (`Graduated`, `Incubating`, `Sandbox`)
-  - Includes `forming_projects` (status: “Formation - Exploratory”)
-  - Includes `archived_projects` (anything not Active or Forming)
+- Fetches PCC projects from LFX and writes `datasources/pcc_projects.yaml` (source of truth)
+  - Active CNCF projects grouped by category (`Graduated`, `Incubating`, `Sandbox`)
+  - `forming_projects` (status: “Formation - Exploratory”)
+  - `archived_projects` (anything not Active or Forming)
 - Downloads a reproducible snapshot of public sources into `datasources/`:
-  - `datasources/landscape.yml`, `datasources/clomonitor.yaml`, `datasources/project-maintainers.csv`, `datasources/devstats.html`, `datasources/artwork.md`
-- Audits against those sources and writes:
-  - `audit/status_audit.md` (Anomalies only; sorted: Graduated → Incubating → Sandbox → Forming → Archived, A–Z within each)
-  - `audit/all_statuses.md` (All projects; Anomalies section first, then the same status sections)
-- Missing values are rendered as “-”. A project is included in Anomalies if:
-  - Any source is missing (“-” for Landscape, empty for others), OR
-  - Any source reports a status different from PCC.
+  - `landscape.yml`, `clomonitor.yaml`, `project-maintainers.csv`, `devstats.html`, `artwork.md`
+- Optionally uses **`datasources/lfx_insights_health.yaml`** when present (from the weekly Insights workflow): **Insights Health** (tier label, e.g. Excellent) and **Health Score** (numeric, e.g. 82). Missing file or per-project gaps show “-”; these columns are **informational only** and **never** affect anomaly detection.
+- Audits and writes:
+  - `audit/status_audit.md` — anomalies only; sorted Graduated → Incubating → Sandbox → Forming → Archived, A–Z within each
+  - `audit/all_statuses.md` — all projects; anomalies section first, then the same status sections
+- Missing values are rendered as “-”. A project is included in **Anomalies** if:
+  - Any **lifecycle** source is missing (“-” for Landscape, empty for CLOMonitor / Maintainers / DevStats / Artwork), OR
+  - Any of those sources reports a status different from PCC.
 
 ## Files
 
-- `scripts/fetch_pcc_projects.py`: Fetches LFX PCC and writes `pcc_projects.yaml`
-- `scripts/audit_landscape_status.py`: Audits external sources and writes both reports
-- `.github/workflows/sync-pcc-and-audit-statuses.yml`: Manual workflow that fetches PCC + sources, runs audits, and opens a PR
-- `pcc_projects.yaml`: Generated, canonical PCC data (no timestamp to avoid noisy diffs)
-- `datasources/`: Snapshot of audited source files (captured by the workflow)
-- `audit/status_audit.md`: Generated anomalies table (mismatches or missing data)
-- `audit/all_statuses.md`: Generated full table of all projects and sources
+| Path | Role |
+|------|------|
+| `scripts/fetch_pcc_projects.py` | Calls LFX PCC API; writes `pcc_projects.yaml` (requires `LFX_TOKEN`) |
+| `scripts/fetch_lfx_insights_health.py` | Builds `lfx_insights_health.yaml` from public LFX Insights endpoints (no token) |
+| `scripts/audit_landscape_status.py` | Compares sources and writes `audit/*.md` |
+| `.github/workflows/sync-pcc-and-audit-statuses.yml` | Manual workflow: PCC + snapshots + audit → PR |
+| `.github/workflows/sync-lfx-insights-health.yml` | Weekly (Sunday UTC) + manual: refresh `lfx_insights_health.yaml` → PR |
+| `datasources/pcc_projects.yaml` | Generated PCC data |
+| `datasources/lfx_insights_health.yaml` | Generated **Insights Health** tier and **Health Score** (optional until first weekly run merges) |
+| `datasources/` | Other source snapshots |
+| `audit/status_audit.md` | Generated anomalies table |
+| `audit/all_statuses.md` | Generated full table |
 
 ## Data sources
 
-- Landscape: `https://raw.githubusercontent.com/cncf/landscape/master/landscape.yml`
-- CLOMonitor: `https://raw.githubusercontent.com/cncf/clomonitor/main/data/cncf.yaml`
-- Foundation Maintainers CSV: `https://raw.githubusercontent.com/cncf/foundation/main/project-maintainers.csv`
-- DevStats: `https://devstats.cncf.io/`
-- Artwork README: `https://raw.githubusercontent.com/cncf/artwork/main/README.md`
+- **PCC:** LFX `project-service` API (see `fetch_pcc_projects.py`)
+- **Landscape:** `https://raw.githubusercontent.com/cncf/landscape/master/landscape.yml`
+- **CLOMonitor:** `https://raw.githubusercontent.com/cncf/clomonitor/main/data/cncf.yaml`
+- **Foundation Maintainers CSV:** `https://raw.githubusercontent.com/cncf/foundation/main/project-maintainers.csv`
+- **DevStats:** `https://devstats.cncf.io/`
+- **Artwork README:** `https://raw.githubusercontent.com/cncf/artwork/main/README.md`
+- **LFX Insights:** Public badge redirect and project overview HTML ([insights.linuxfoundation.org](https://insights.linuxfoundation.org/)); slugs align with PCC `slug` where available.
 
 ## GitHub Actions (recommended)
 
-1. Add a repo secret `LFX_TOKEN` with a valid LF PCC API token.
-2. Ensure Actions permissions allow “Read and write permissions” and PR creation for the `GITHUB_TOKEN`.
-3. Trigger the workflow:
-   - GitHub → Actions → “Sync PCC and Audit CNCF Project Statuses” → “Run workflow”
-4. Review the PR with updates to:
-   - `pcc_projects.yaml`
-   - `datasources/**`
-   - `audit/status_audit.md`
-   - `audit/all_statuses.md`
+### PCC sync + audit
+
+1. Add repo secret **`LFX_TOKEN`** with a valid LF PCC API token.
+2. Ensure Actions can write contents and open PRs with `GITHUB_TOKEN`.
+3. **Actions → “Sync PCC and Audit CNCF Project Statuses” → Run workflow**
+4. Review the PR: `pcc_projects.yaml`, `datasources/**`, `audit/status_audit.md`, `audit/all_statuses.md`
+
+### LFX Insights health snapshot (no `LFX_TOKEN`)
+
+1. **Actions → “Sync LFX Insights health scores” → Run workflow** (or wait for the weekly Sunday schedule).
+2. Merge the PR that updates `datasources/lfx_insights_health.yaml`.
+3. Run the PCC audit workflow again (or merge a branch that already includes the health file) so the **Insights Health** and **Health Score** columns populate.
 
 ## Run locally
 
-Dependencies:
-- Python 3.11+
-- pip packages: `requests`, `pyyaml`, `beautifulsoup4`
+Dependencies: Python 3.11+; `pip install requests pyyaml beautifulsoup4`
 
-Generate PCC YAML (writes to `datasources/pcc_projects.yaml`):
+**PCC YAML** (writes `datasources/pcc_projects.yaml`):
 
 ```bash
 export LFX_TOKEN=your_lfx_token
+cd utilities/audit_project_lifecycle_across_tools
 python scripts/fetch_pcc_projects.py
 ```
 
-Run the audits:
+**LFX Insights health snapshot** (writes `datasources/lfx_insights_health.yaml`; requires `pcc_projects.yaml`):
 
 ```bash
+cd utilities/audit_project_lifecycle_across_tools
+python scripts/fetch_lfx_insights_health.py
+# Optional: python scripts/fetch_lfx_insights_health.py --max-projects 10
+```
+
+**Audit reports:**
+
+```bash
+cd utilities/audit_project_lifecycle_across_tools
 python scripts/audit_landscape_status.py
 ```
 
-Outputs:
-- `datasources/pcc_projects.yaml`
-- `datasources/**` snapshot (if files were not already present for other sources)
-- `audit/status_audit.md` (anomalies only, missing data as “-”)
-- `audit/all_statuses.md` (all projects: anomalies first, then by status group)
+Outputs: `audit/status_audit.md`, `audit/all_statuses.md`, and any missing `datasources/*` snapshots downloaded on first run.
 
 ## Notes and assumptions
 
-- PCC is the source of truth; we compare maturity/status labels from external sources to PCC categories:
-  - Graduated, Incubating, Sandbox, Archived, Forming (Formation - Exploratory)
-- TAGs are intentionally excluded from the PCC categories section.
-- PCC entries with `status: Formation - Disengaged` are intentionally excluded from the audit outputs
-  (`audit/status_audit.md` and `audit/all_statuses.md`).
-- PCC entries with `status: Formation - Engaged` are treated as `Forming` in the audit outputs.
-- The workflow snapshots audited sources into `datasources/**` and includes them in the PR for reproducibility.
-- Landscape matching improvements to reduce name variance issues:
-  - Aliases from parentheses/acronyms (e.g., “Open Policy Agent (OPA)”, “KAITO”, “ORAS”)
-  - Common suffix trimming (“Project”, “Specification”, “Operator”, “Framework”)
-  - Unicode normalization (e.g., “Metal³” → “metal3”), lfx_slug alias, and hyphen/space variants
-- DevStats parsing uses the page’s row headings (“Graduated”, “Incubating”, “Sandbox”, “Archived”) to derive statuses.
-
+- PCC is the source of truth for **lifecycle** labels; external sources are compared to PCC categories (Graduated, Incubating, Sandbox, Archived, Forming, Prospect as applicable).
+- **Insights Health** / **Health Score** are informational (not compared to PCC lifecycle).
+- TAGs are excluded from the PCC categories section in `pcc_projects.yaml`.
+- PCC entries with `status: Formation - Disengaged` are excluded from audit outputs.
+- PCC entries with `status: Formation - Engaged` are treated as **Forming** in the audit.
+- Landscape matching uses aliases (parentheticals, suffix trimming, Unicode normalization, `lfx_slug`, hyphen/space variants) — see `audit_landscape_status.py`.
+- DevStats parsing uses page row headings (“Graduated”, “Incubating”, “Sandbox”, “Archived”).

--- a/utilities/audit_project_lifecycle_across_tools/audit/all_statuses.md
+++ b/utilities/audit_project_lifecycle_across_tools/audit/all_statuses.md
@@ -2,368 +2,368 @@
 
 ## Anomalies
 
-| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) |
-|---|---|---|---|---|---|---|
-| Agones | sandbox | - | - | - | sandbox | - |
-| CoHDI | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| composefs | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Copa | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| kube-vip | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Oxia | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Service Mesh Performance | sandbox | archived | - | - | - | archived |
-| TrestleGRC | sandbox | sandbox | - | - | sandbox | - |
-| Velero | sandbox | - | - | - | sandbox | - |
-| <QHTTPX> | forming | - | - | - | - | - |
-| AIBrix | forming | - | - | - | - | - |
-| Apicurio Registry | forming | - | - | - | - | - |
-| BLAFS | forming | - | - | - | - | - |
-| Cedar | forming | sandbox | - | sandbox | - | - |
-| CNCF Standards & Specifications | forming | - | - | - | - | - |
-| CNCF Toolbox | forming | - | - | - | - | - |
-| Conveyor CI | forming | - | - | - | - | - |
-| Cruise | forming | - | - | - | - | - |
-| CubeCOS | forming | - | - | - | - | - |
-| Curvine | forming | - | - | - | - | - |
-| DevOps AI Toolkit | forming | - | - | - | - | - |
-| Dexfile | forming | - | - | - | - | - |
-| Gthulhu | forming | - | - | - | - | - |
-| Higress | forming | sandbox | - | - | - | - |
-| KAI Scheduler | forming | sandbox | - | sandbox | sandbox | - |
-| Kmesh | forming | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ksctl | forming | - | - | - | - | - |
-| kube-bind | forming | - | - | - | - | - |
-| KubeElasti | forming | sandbox | - | sandbox | sandbox | - |
-| llm-d | forming | - | - | - | - | - |
-| NMstate | forming | - | - | - | - | - |
-| OpenEverest | forming | sandbox | - | - | - | - |
-| OptiFlow (AI‑OrchestrateX) | forming | - | - | - | - | - |
-| Schema Driven Configuration | forming | - | - | - | - | - |
-| SecureBuild | forming | - | - | - | - | - |
-| SemaMesh | forming | - | - | - | - | - |
-| Sermant | forming | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ServiceRadar | forming | - | - | - | - | - |
-| Terrascan | forming | - | - | - | - | - |
-| Brigade | archived | archived | - | - | - | archived |
-| CNI-Genie | archived | archived | - | - | - | - |
-| Curiefense | archived | archived | - | - | - | archived |
-| Curve | archived | archived | - | - | - | archived |
-| Devstream | archived | archived | - | - | - | archived |
-| FabEdge | archived | archived | - | - | - | archived |
-| Fonio | archived | archived | - | - | - | archived |
-| Keptn | archived | archived | - | - | - | archived |
-| Krator | archived | archived | - | - | - | archived |
-| Krustlet | archived | archived | - | - | - | archived |
-| KubeDL | archived | archived | - | - | - | archived |
-| Merbridge | archived | archived | - | - | - | archived |
-| Nocalhost | archived | archived | - | - | - | archived |
-| Open Service Mesh | archived | archived | - | - | - | archived |
-| OpenELB | archived | archived | - | - | - | archived |
-| OpenMetrics | archived | archived | - | - | - | archived |
-| OpenTracing | archived | archived | - | - | - | archived |
-| Pravega | archived | archived | - | - | - | archived |
-| RKT | archived | archived | - | - | - | archived |
-| sealer | archived | archived | - | - | - | archived |
-| Service Mesh Interface | archived | archived | - | - | - | archived |
-| skooner | archived | archived | - | - | - | archived |
-| SuperEdge | archived | archived | - | - | - | archived |
-| Teller | archived | archived | - | - | - | archived |
-| Xline | archived | archived | - | - | - | archived |
+| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |
+|---|---|---|---|---|---|---|---|---|
+| Agones | sandbox | - | - | - | sandbox | - | - | - |
+| CoHDI | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| composefs | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Copa | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| kube-vip | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Oxia | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Service Mesh Performance | sandbox | archived | - | - | - | archived | - | - |
+| TrestleGRC | sandbox | sandbox | - | - | sandbox | - | - | - |
+| Velero | sandbox | - | - | - | sandbox | - | - | - |
+| <QHTTPX> | forming | - | - | - | - | - | - | - |
+| AIBrix | forming | - | - | - | - | - | - | - |
+| Apicurio Registry | forming | - | - | - | - | - | - | - |
+| BLAFS | forming | - | - | - | - | - | - | - |
+| Cedar | forming | sandbox | - | sandbox | - | - | - | - |
+| CNCF Standards & Specifications | forming | - | - | - | - | - | - | - |
+| CNCF Toolbox | forming | - | - | - | - | - | - | - |
+| Conveyor CI | forming | - | - | - | - | - | - | - |
+| Cruise | forming | - | - | - | - | - | - | - |
+| CubeCOS | forming | - | - | - | - | - | - | - |
+| Curvine | forming | - | - | - | - | - | - | - |
+| DevOps AI Toolkit | forming | - | - | - | - | - | - | - |
+| Dexfile | forming | - | - | - | - | - | - | - |
+| Gthulhu | forming | - | - | - | - | - | - | - |
+| Higress | forming | sandbox | - | - | - | - | - | - |
+| KAI Scheduler | forming | sandbox | - | sandbox | sandbox | - | - | - |
+| Kmesh | forming | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ksctl | forming | - | - | - | - | - | - | - |
+| kube-bind | forming | - | - | - | - | - | - | - |
+| KubeElasti | forming | sandbox | - | sandbox | sandbox | - | - | - |
+| llm-d | forming | - | - | - | - | - | - | - |
+| NMstate | forming | - | - | - | - | - | - | - |
+| OpenEverest | forming | sandbox | - | - | - | - | - | - |
+| OptiFlow (AI‑OrchestrateX) | forming | - | - | - | - | - | - | - |
+| Schema Driven Configuration | forming | - | - | - | - | - | - | - |
+| SecureBuild | forming | - | - | - | - | - | - | - |
+| SemaMesh | forming | - | - | - | - | - | - | - |
+| Sermant | forming | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ServiceRadar | forming | - | - | - | - | - | - | - |
+| Terrascan | forming | - | - | - | - | - | - | - |
+| Brigade | archived | archived | - | - | - | archived | - | - |
+| CNI-Genie | archived | archived | - | - | - | - | - | - |
+| Curiefense | archived | archived | - | - | - | archived | - | - |
+| Curve | archived | archived | - | - | - | archived | - | - |
+| Devstream | archived | archived | - | - | - | archived | - | - |
+| FabEdge | archived | archived | - | - | - | archived | - | - |
+| Fonio | archived | archived | - | - | - | archived | - | - |
+| Keptn | archived | archived | - | - | - | archived | - | - |
+| Krator | archived | archived | - | - | - | archived | - | - |
+| Krustlet | archived | archived | - | - | - | archived | - | - |
+| KubeDL | archived | archived | - | - | - | archived | - | - |
+| Merbridge | archived | archived | - | - | - | archived | - | - |
+| Nocalhost | archived | archived | - | - | - | archived | - | - |
+| Open Service Mesh | archived | archived | - | - | - | archived | - | - |
+| OpenELB | archived | archived | - | - | - | archived | - | - |
+| OpenMetrics | archived | archived | - | - | - | archived | - | - |
+| OpenTracing | archived | archived | - | - | - | archived | - | - |
+| Pravega | archived | archived | - | - | - | archived | - | - |
+| RKT | archived | archived | - | - | - | archived | - | - |
+| sealer | archived | archived | - | - | - | archived | - | - |
+| Service Mesh Interface | archived | archived | - | - | - | archived | - | - |
+| skooner | archived | archived | - | - | - | archived | - | - |
+| SuperEdge | archived | archived | - | - | - | archived | - | - |
+| Teller | archived | archived | - | - | - | archived | - | - |
+| Xline | archived | archived | - | - | - | archived | - | - |
 
 ## Graduated
 
-| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) |
-|---|---|---|---|---|---|---|
-| Argo | graduated | graduated | graduated | graduated | graduated | graduated |
-| cert-manager | graduated | graduated | graduated | graduated | graduated | graduated |
-| Cilium | graduated | graduated | graduated | graduated | graduated | graduated |
-| CloudEvents | graduated | graduated | graduated | graduated | graduated | graduated |
-| Containerd | graduated | graduated | graduated | graduated | graduated | graduated |
-| CoreDNS | graduated | graduated | graduated | graduated | graduated | graduated |
-| CRI-O | graduated | graduated | graduated | graduated | graduated | graduated |
-| Crossplane | graduated | graduated | graduated | graduated | graduated | graduated |
-| CubeFS | graduated | graduated | graduated | graduated | graduated | graduated |
-| Dapr | graduated | graduated | graduated | graduated | graduated | graduated |
-| Dragonfly | graduated | graduated | graduated | graduated | graduated | graduated |
-| Envoy | graduated | graduated | graduated | graduated | graduated | graduated |
-| Etcd | graduated | graduated | graduated | graduated | graduated | graduated |
-| Falco | graduated | graduated | graduated | graduated | graduated | graduated |
-| Fluentd | graduated | graduated | graduated | graduated | graduated | graduated |
-| Flux | graduated | graduated | graduated | graduated | graduated | graduated |
-| Harbor | graduated | graduated | graduated | graduated | graduated | graduated |
-| Helm | graduated | graduated | graduated | graduated | graduated | graduated |
-| in-toto | graduated | graduated | graduated | graduated | graduated | graduated |
-| Istio | graduated | graduated | graduated | graduated | graduated | graduated |
-| Jaeger | graduated | graduated | graduated | graduated | graduated | graduated |
-| KEDA | graduated | graduated | graduated | graduated | graduated | graduated |
-| Knative | graduated | graduated | graduated | graduated | graduated | graduated |
-| KubeEdge | graduated | graduated | graduated | graduated | graduated | graduated |
-| Kubernetes | graduated | graduated | graduated | graduated | graduated | graduated |
-| Kyverno | graduated | graduated | graduated | graduated | graduated | graduated |
-| Linkerd | graduated | graduated | graduated | graduated | graduated | graduated |
-| Open Policy Agent | graduated | graduated | graduated | graduated | graduated | graduated |
-| Prometheus | graduated | graduated | graduated | graduated | graduated | graduated |
-| Rook | graduated | graduated | graduated | graduated | graduated | graduated |
-| SPIFFE | graduated | graduated | graduated | graduated | graduated | graduated |
-| SPIRE | graduated | graduated | graduated | graduated | graduated | graduated |
-| The Update Framework (TUF) | graduated | graduated | graduated | graduated | graduated | graduated |
-| TiKV | graduated | graduated | graduated | graduated | graduated | graduated |
-| Vitess | graduated | graduated | graduated | graduated | graduated | graduated |
+| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |
+|---|---|---|---|---|---|---|---|---|
+| Argo | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| cert-manager | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Cilium | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| CloudEvents | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Containerd | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| CoreDNS | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| CRI-O | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Crossplane | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| CubeFS | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Dapr | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Dragonfly | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Envoy | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Etcd | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Falco | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Fluentd | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Flux | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Harbor | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Helm | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| in-toto | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Istio | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Jaeger | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| KEDA | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Knative | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| KubeEdge | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Kubernetes | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Kyverno | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Linkerd | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Open Policy Agent | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Prometheus | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Rook | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| SPIFFE | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| SPIRE | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| The Update Framework (TUF) | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| TiKV | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
+| Vitess | graduated | graduated | graduated | graduated | graduated | graduated | - | - |
 
 ## Incubating
 
-| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) |
-|---|---|---|---|---|---|---|
-| Artifact Hub | incubating | incubating | incubating | incubating | incubating | incubating |
-| Backstage | incubating | incubating | incubating | incubating | incubating | incubating |
-| Buildpacks | incubating | incubating | incubating | incubating | incubating | incubating |
-| Chaos Mesh | incubating | incubating | incubating | incubating | incubating | incubating |
-| Cloud Custodian | incubating | incubating | incubating | incubating | incubating | incubating |
-| CNI | incubating | incubating | incubating | incubating | incubating | incubating |
-| Contour | incubating | incubating | incubating | incubating | incubating | incubating |
-| Cortex | incubating | incubating | incubating | incubating | incubating | incubating |
-| emissary-ingress | incubating | incubating | incubating | incubating | incubating | incubating |
-| Flatcar | incubating | incubating | incubating | incubating | incubating | incubating |
-| Fluid Project | incubating | incubating | incubating | incubating | incubating | incubating |
-| gRPC | incubating | incubating | incubating | incubating | incubating | incubating |
-| karmada | incubating | incubating | incubating | incubating | incubating | incubating |
-| Keycloak | incubating | incubating | incubating | incubating | incubating | incubating |
-| Kserve | incubating | incubating | incubating | incubating | incubating | incubating |
-| Kubeflow | incubating | incubating | incubating | incubating | incubating | incubating |
-| Kubescape | incubating | incubating | incubating | incubating | incubating | incubating |
-| KubeVela | incubating | incubating | incubating | incubating | incubating | incubating |
-| KubeVirt | incubating | incubating | incubating | incubating | incubating | incubating |
-| Lima | incubating | incubating | incubating | incubating | incubating | incubating |
-| LitmusChaos | incubating | incubating | incubating | incubating | incubating | incubating |
-| Longhorn | incubating | incubating | incubating | incubating | incubating | incubating |
-| metal3-io | incubating | incubating | incubating | incubating | incubating | incubating |
-| NATS | incubating | incubating | incubating | incubating | incubating | incubating |
-| Notary | incubating | incubating | incubating | incubating | incubating | incubating |
-| OpenCost | incubating | incubating | incubating | incubating | incubating | incubating |
-| OpenFeature | incubating | incubating | incubating | incubating | incubating | incubating |
-| OpenFGA | incubating | incubating | incubating | incubating | incubating | incubating |
-| OpenKruise | incubating | incubating | incubating | incubating | incubating | incubating |
-| OpenTelemetry | incubating | incubating | incubating | incubating | incubating | incubating |
-| OpenYurt | incubating | incubating | incubating | incubating | incubating | incubating |
-| Operator Framework | incubating | incubating | incubating | incubating | incubating | incubating |
-| Strimzi | incubating | incubating | incubating | incubating | incubating | incubating |
-| Thanos | incubating | incubating | incubating | incubating | incubating | incubating |
-| Volcano | incubating | incubating | incubating | incubating | incubating | incubating |
-| wasmCloud | incubating | incubating | incubating | incubating | incubating | incubating |
+| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |
+|---|---|---|---|---|---|---|---|---|
+| Artifact Hub | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Backstage | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Buildpacks | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Chaos Mesh | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Cloud Custodian | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| CNI | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Contour | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Cortex | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| emissary-ingress | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Flatcar | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Fluid Project | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| gRPC | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| karmada | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Keycloak | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Kserve | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Kubeflow | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Kubescape | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| KubeVela | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| KubeVirt | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Lima | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| LitmusChaos | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Longhorn | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| metal3-io | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| NATS | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Notary | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| OpenCost | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| OpenFeature | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| OpenFGA | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| OpenKruise | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| OpenTelemetry | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| OpenYurt | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Operator Framework | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Strimzi | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Thanos | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| Volcano | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
+| wasmCloud | incubating | incubating | incubating | incubating | incubating | incubating | - | - |
 
 ## Sandbox
 
-| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) |
-|---|---|---|---|---|---|---|
-| Aeraki Mesh | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Agones | sandbox | - | - | - | sandbox | - |
-| Akri | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Antrea | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Armada | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Athenz | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Atlantis | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Bank-Vaults | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| BFE | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| bootc | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| bpfman | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Cadence | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Capsule | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Carina | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Cartography | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Carvel | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| cdk8s | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ChaosBlade | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| CloudNativePG | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Clusternet | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Clusterpedia | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| CoHDI | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| composefs | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Confidential Containers | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Connect RPC | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| container2wasm | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ContainerSSH | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Copa | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Cozystack | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Dalec | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Devfile | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| DevSpace | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Dex | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Distribution | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Drasi | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| easegress | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Eraser | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| External Secrets Operator | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| HAMi | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Headlamp | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Hexa | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| HolmesGPT | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| HwameiStor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Hyperlight | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Inclavare Containers | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Inspektor Gadget | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| interLink | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| k0s | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| k3s | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| k8gb | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| K8sGPT | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| K8up | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kagent | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kairos | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kanister | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KCL | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kcp | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kepler | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Keylime | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kgateway | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KitOps | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ko | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Konveyor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Koordinator | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kpt | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| krkn | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kuadrant | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kuasar | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kube-burner | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kube-OVN | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kube-rs | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kube-vip | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Kubean | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KubeArmor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kubeclipper | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KubeFleet | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kuberhealthy | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kubernetes AI Toolchain Operator (KAITO) | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KubeSlice | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KubeStellar | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| kubewarden | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KUDO | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kuma | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Kured | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| KusionStack | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Logging Operator | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| LoxiLB | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Meshery | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| MetalLB | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Microcks | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ModelPack | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Network Service Mesh | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| OAuth2 Proxy | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Open Cluster Management | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Open Policy Registry (OPCR) | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| OpenChoreo | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| OpenEBS | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| OpenFunction | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| openGemini | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| OpenGitOps | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| OpenTofu | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ORAS (OCI Registry as Storage) | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| OVN-Kubernetes | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Oxia | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Paralus | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| PARSEC | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Perses | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| PipeCD | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Piraeus-Datastore | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Pixie | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Podman Container Tools | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Podman Desktop | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Porter | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Radius | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Ratify | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Runme Notebooks | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| SchemaHero | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Score | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Serverless Devs | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Serverless Workflow Specification | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Service Mesh Performance | sandbox | archived | - | - | - | archived |
-| Shipwright | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| SlimFaaS | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| SlimToolkit | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| SOPS | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Spiderpool | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Spin | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| stacker | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Submariner | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Telepresence | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Tinkerbell | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Tokenetes | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Tremor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| TrestleGRC | sandbox | sandbox | - | - | sandbox | - |
-| Trickster | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| urunc | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Velero | sandbox | - | - | - | sandbox | - |
-| Vineyard | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Virtual Kubelet | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| VS Code Kubernetes Tools | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| WasmEdge Runtime | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| werf | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| xRegistry | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| Youki | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
-| zot | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox |
+| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |
+|---|---|---|---|---|---|---|---|---|
+| Aeraki Mesh | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Agones | sandbox | - | - | - | sandbox | - | - | - |
+| Akri | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Antrea | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Armada | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Athenz | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Atlantis | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Bank-Vaults | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| BFE | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| bootc | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| bpfman | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Cadence | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Capsule | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Carina | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Cartography | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Carvel | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| cdk8s | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ChaosBlade | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| CloudNativePG | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Clusternet | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Clusterpedia | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| CoHDI | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| composefs | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Confidential Containers | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Connect RPC | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| container2wasm | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ContainerSSH | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Copa | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Cozystack | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Dalec | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Devfile | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| DevSpace | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Dex | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Distribution | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Drasi | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| easegress | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Eraser | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| External Secrets Operator | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| HAMi | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Headlamp | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Hexa | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| HolmesGPT | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| HwameiStor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Hyperlight | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Inclavare Containers | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Inspektor Gadget | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| interLink | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| k0s | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| k3s | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| k8gb | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| K8sGPT | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| K8up | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kagent | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kairos | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kanister | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KCL | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kcp | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kepler | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Keylime | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kgateway | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KitOps | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ko | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Konveyor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Koordinator | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kpt | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| krkn | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kuadrant | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kuasar | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kube-burner | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kube-OVN | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kube-rs | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kube-vip | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Kubean | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KubeArmor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kubeclipper | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KubeFleet | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kuberhealthy | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kubernetes AI Toolchain Operator (KAITO) | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KubeSlice | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KubeStellar | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| kubewarden | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KUDO | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kuma | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Kured | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| KusionStack | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Logging Operator | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| LoxiLB | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Meshery | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| MetalLB | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Microcks | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ModelPack | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Network Service Mesh | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| OAuth2 Proxy | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Open Cluster Management | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Open Policy Registry (OPCR) | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| OpenChoreo | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| OpenEBS | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| OpenFunction | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| openGemini | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| OpenGitOps | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| OpenTofu | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ORAS (OCI Registry as Storage) | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| OVN-Kubernetes | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Oxia | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Paralus | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| PARSEC | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Perses | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| PipeCD | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Piraeus-Datastore | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Pixie | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Podman Container Tools | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Podman Desktop | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Porter | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Radius | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Ratify | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Runme Notebooks | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| SchemaHero | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Score | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Serverless Devs | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Serverless Workflow Specification | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Service Mesh Performance | sandbox | archived | - | - | - | archived | - | - |
+| Shipwright | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| SlimFaaS | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| SlimToolkit | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| SOPS | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Spiderpool | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Spin | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| stacker | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Submariner | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Telepresence | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Tinkerbell | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Tokenetes | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Tremor | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| TrestleGRC | sandbox | sandbox | - | - | sandbox | - | - | - |
+| Trickster | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| urunc | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Velero | sandbox | - | - | - | sandbox | - | - | - |
+| Vineyard | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Virtual Kubelet | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| VS Code Kubernetes Tools | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| WasmEdge Runtime | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| werf | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| xRegistry | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| Youki | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| zot | sandbox | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
 
 ## Forming
 
-| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) |
-|---|---|---|---|---|---|---|
-| <QHTTPX> | forming | - | - | - | - | - |
-| AIBrix | forming | - | - | - | - | - |
-| Apicurio Registry | forming | - | - | - | - | - |
-| BLAFS | forming | - | - | - | - | - |
-| Cedar | forming | sandbox | - | sandbox | - | - |
-| CNCF Standards & Specifications | forming | - | - | - | - | - |
-| CNCF Toolbox | forming | - | - | - | - | - |
-| Conveyor CI | forming | - | - | - | - | - |
-| Cruise | forming | - | - | - | - | - |
-| CubeCOS | forming | - | - | - | - | - |
-| Curvine | forming | - | - | - | - | - |
-| DevOps AI Toolkit | forming | - | - | - | - | - |
-| Dexfile | forming | - | - | - | - | - |
-| Gthulhu | forming | - | - | - | - | - |
-| Higress | forming | sandbox | - | - | - | - |
-| KAI Scheduler | forming | sandbox | - | sandbox | sandbox | - |
-| Kmesh | forming | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ksctl | forming | - | - | - | - | - |
-| kube-bind | forming | - | - | - | - | - |
-| KubeElasti | forming | sandbox | - | sandbox | sandbox | - |
-| llm-d | forming | - | - | - | - | - |
-| NMstate | forming | - | - | - | - | - |
-| OpenEverest | forming | sandbox | - | - | - | - |
-| OptiFlow (AI‑OrchestrateX) | forming | - | - | - | - | - |
-| Schema Driven Configuration | forming | - | - | - | - | - |
-| SecureBuild | forming | - | - | - | - | - |
-| SemaMesh | forming | - | - | - | - | - |
-| Sermant | forming | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ServiceRadar | forming | - | - | - | - | - |
-| Terrascan | forming | - | - | - | - | - |
+| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |
+|---|---|---|---|---|---|---|---|---|
+| <QHTTPX> | forming | - | - | - | - | - | - | - |
+| AIBrix | forming | - | - | - | - | - | - | - |
+| Apicurio Registry | forming | - | - | - | - | - | - | - |
+| BLAFS | forming | - | - | - | - | - | - | - |
+| Cedar | forming | sandbox | - | sandbox | - | - | - | - |
+| CNCF Standards & Specifications | forming | - | - | - | - | - | - | - |
+| CNCF Toolbox | forming | - | - | - | - | - | - | - |
+| Conveyor CI | forming | - | - | - | - | - | - | - |
+| Cruise | forming | - | - | - | - | - | - | - |
+| CubeCOS | forming | - | - | - | - | - | - | - |
+| Curvine | forming | - | - | - | - | - | - | - |
+| DevOps AI Toolkit | forming | - | - | - | - | - | - | - |
+| Dexfile | forming | - | - | - | - | - | - | - |
+| Gthulhu | forming | - | - | - | - | - | - | - |
+| Higress | forming | sandbox | - | - | - | - | - | - |
+| KAI Scheduler | forming | sandbox | - | sandbox | sandbox | - | - | - |
+| Kmesh | forming | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ksctl | forming | - | - | - | - | - | - | - |
+| kube-bind | forming | - | - | - | - | - | - | - |
+| KubeElasti | forming | sandbox | - | sandbox | sandbox | - | - | - |
+| llm-d | forming | - | - | - | - | - | - | - |
+| NMstate | forming | - | - | - | - | - | - | - |
+| OpenEverest | forming | sandbox | - | - | - | - | - | - |
+| OptiFlow (AI‑OrchestrateX) | forming | - | - | - | - | - | - | - |
+| Schema Driven Configuration | forming | - | - | - | - | - | - | - |
+| SecureBuild | forming | - | - | - | - | - | - | - |
+| SemaMesh | forming | - | - | - | - | - | - | - |
+| Sermant | forming | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ServiceRadar | forming | - | - | - | - | - | - | - |
+| Terrascan | forming | - | - | - | - | - | - | - |
 
 ## Archived
 
-| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) |
-|---|---|---|---|---|---|---|
-| Brigade | archived | archived | - | - | - | archived |
-| CNI-Genie | archived | archived | - | - | - | - |
-| Curiefense | archived | archived | - | - | - | archived |
-| Curve | archived | archived | - | - | - | archived |
-| Devstream | archived | archived | - | - | - | archived |
-| FabEdge | archived | archived | - | - | - | archived |
-| Fonio | archived | archived | - | - | - | archived |
-| Keptn | archived | archived | - | - | - | archived |
-| Krator | archived | archived | - | - | - | archived |
-| Krustlet | archived | archived | - | - | - | archived |
-| KubeDL | archived | archived | - | - | - | archived |
-| Merbridge | archived | archived | - | - | - | archived |
-| Nocalhost | archived | archived | - | - | - | archived |
-| Open Service Mesh | archived | archived | - | - | - | archived |
-| OpenELB | archived | archived | - | - | - | archived |
-| OpenMetrics | archived | archived | - | - | - | archived |
-| OpenTracing | archived | archived | - | - | - | archived |
-| Pravega | archived | archived | - | - | - | archived |
-| RKT | archived | archived | - | - | - | archived |
-| sealer | archived | archived | - | - | - | archived |
-| Service Mesh Interface | archived | archived | - | - | - | archived |
-| skooner | archived | archived | - | - | - | archived |
-| SuperEdge | archived | archived | - | - | - | archived |
-| Teller | archived | archived | - | - | - | archived |
-| Xline | archived | archived | - | - | - | archived |
+| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |
+|---|---|---|---|---|---|---|---|---|
+| Brigade | archived | archived | - | - | - | archived | - | - |
+| CNI-Genie | archived | archived | - | - | - | - | - | - |
+| Curiefense | archived | archived | - | - | - | archived | - | - |
+| Curve | archived | archived | - | - | - | archived | - | - |
+| Devstream | archived | archived | - | - | - | archived | - | - |
+| FabEdge | archived | archived | - | - | - | archived | - | - |
+| Fonio | archived | archived | - | - | - | archived | - | - |
+| Keptn | archived | archived | - | - | - | archived | - | - |
+| Krator | archived | archived | - | - | - | archived | - | - |
+| Krustlet | archived | archived | - | - | - | archived | - | - |
+| KubeDL | archived | archived | - | - | - | archived | - | - |
+| Merbridge | archived | archived | - | - | - | archived | - | - |
+| Nocalhost | archived | archived | - | - | - | archived | - | - |
+| Open Service Mesh | archived | archived | - | - | - | archived | - | - |
+| OpenELB | archived | archived | - | - | - | archived | - | - |
+| OpenMetrics | archived | archived | - | - | - | archived | - | - |
+| OpenTracing | archived | archived | - | - | - | archived | - | - |
+| Pravega | archived | archived | - | - | - | archived | - | - |
+| RKT | archived | archived | - | - | - | archived | - | - |
+| sealer | archived | archived | - | - | - | archived | - | - |
+| Service Mesh Interface | archived | archived | - | - | - | archived | - | - |
+| skooner | archived | archived | - | - | - | archived | - | - |
+| SuperEdge | archived | archived | - | - | - | archived | - | - |
+| Teller | archived | archived | - | - | - | archived | - | - |
+| Xline | archived | archived | - | - | - | archived | - | - |
 
 ## Prospect
 

--- a/utilities/audit_project_lifecycle_across_tools/audit/status_audit.md
+++ b/utilities/audit_project_lifecycle_across_tools/audit/status_audit.md
@@ -1,68 +1,68 @@
 # CNCF Project Status Audit
 
-| Project | [PCC status](./pcc_projects.yaml) | [Landscape status](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor status](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers CSV status](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats status](https://devstats.cncf.io/) | [Artwork status](https://github.com/cncf/artwork/blob/main/README.md) |
-|---|---|---|---|---|---|---|
-| Agones | sandbox | - | - | - | sandbox | - |
-| CoHDI | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| composefs | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Copa | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| kube-vip | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Oxia | sandbox | sandbox | sandbox | sandbox | sandbox | - |
-| Service Mesh Performance | sandbox | archived | - | - | - | archived |
-| TrestleGRC | sandbox | sandbox | - | - | sandbox | - |
-| Velero | sandbox | - | - | - | sandbox | - |
-| <QHTTPX> | forming | - | - | - | - | - |
-| AIBrix | forming | - | - | - | - | - |
-| Apicurio Registry | forming | - | - | - | - | - |
-| BLAFS | forming | - | - | - | - | - |
-| Cedar | forming | sandbox | - | sandbox | - | - |
-| CNCF Standards & Specifications | forming | - | - | - | - | - |
-| CNCF Toolbox | forming | - | - | - | - | - |
-| Conveyor CI | forming | - | - | - | - | - |
-| Cruise | forming | - | - | - | - | - |
-| CubeCOS | forming | - | - | - | - | - |
-| Curvine | forming | - | - | - | - | - |
-| DevOps AI Toolkit | forming | - | - | - | - | - |
-| Dexfile | forming | - | - | - | - | - |
-| Gthulhu | forming | - | - | - | - | - |
-| Higress | forming | sandbox | - | - | - | - |
-| KAI Scheduler | forming | sandbox | - | sandbox | sandbox | - |
-| Kmesh | forming | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ksctl | forming | - | - | - | - | - |
-| kube-bind | forming | - | - | - | - | - |
-| KubeElasti | forming | sandbox | - | sandbox | sandbox | - |
-| llm-d | forming | - | - | - | - | - |
-| NMstate | forming | - | - | - | - | - |
-| OpenEverest | forming | sandbox | - | - | - | - |
-| OptiFlow (AI‑OrchestrateX) | forming | - | - | - | - | - |
-| Schema Driven Configuration | forming | - | - | - | - | - |
-| SecureBuild | forming | - | - | - | - | - |
-| SemaMesh | forming | - | - | - | - | - |
-| Sermant | forming | sandbox | sandbox | sandbox | sandbox | sandbox |
-| ServiceRadar | forming | - | - | - | - | - |
-| Terrascan | forming | - | - | - | - | - |
-| Brigade | archived | archived | - | - | - | archived |
-| CNI-Genie | archived | archived | - | - | - | - |
-| Curiefense | archived | archived | - | - | - | archived |
-| Curve | archived | archived | - | - | - | archived |
-| Devstream | archived | archived | - | - | - | archived |
-| FabEdge | archived | archived | - | - | - | archived |
-| Fonio | archived | archived | - | - | - | archived |
-| Keptn | archived | archived | - | - | - | archived |
-| Krator | archived | archived | - | - | - | archived |
-| Krustlet | archived | archived | - | - | - | archived |
-| KubeDL | archived | archived | - | - | - | archived |
-| Merbridge | archived | archived | - | - | - | archived |
-| Nocalhost | archived | archived | - | - | - | archived |
-| Open Service Mesh | archived | archived | - | - | - | archived |
-| OpenELB | archived | archived | - | - | - | archived |
-| OpenMetrics | archived | archived | - | - | - | archived |
-| OpenTracing | archived | archived | - | - | - | archived |
-| Pravega | archived | archived | - | - | - | archived |
-| RKT | archived | archived | - | - | - | archived |
-| sealer | archived | archived | - | - | - | archived |
-| Service Mesh Interface | archived | archived | - | - | - | archived |
-| skooner | archived | archived | - | - | - | archived |
-| SuperEdge | archived | archived | - | - | - | archived |
-| Teller | archived | archived | - | - | - | archived |
-| Xline | archived | archived | - | - | - | archived |
+| Project | [PCC status](./pcc_projects.yaml) | [Landscape status](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor status](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers CSV status](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats status](https://devstats.cncf.io/) | [Artwork status](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |
+|---|---|---|---|---|---|---|---|---|
+| Agones | sandbox | - | - | - | sandbox | - | - | - |
+| CoHDI | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| composefs | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Copa | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| kube-vip | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Oxia | sandbox | sandbox | sandbox | sandbox | sandbox | - | - | - |
+| Service Mesh Performance | sandbox | archived | - | - | - | archived | - | - |
+| TrestleGRC | sandbox | sandbox | - | - | sandbox | - | - | - |
+| Velero | sandbox | - | - | - | sandbox | - | - | - |
+| <QHTTPX> | forming | - | - | - | - | - | - | - |
+| AIBrix | forming | - | - | - | - | - | - | - |
+| Apicurio Registry | forming | - | - | - | - | - | - | - |
+| BLAFS | forming | - | - | - | - | - | - | - |
+| Cedar | forming | sandbox | - | sandbox | - | - | - | - |
+| CNCF Standards & Specifications | forming | - | - | - | - | - | - | - |
+| CNCF Toolbox | forming | - | - | - | - | - | - | - |
+| Conveyor CI | forming | - | - | - | - | - | - | - |
+| Cruise | forming | - | - | - | - | - | - | - |
+| CubeCOS | forming | - | - | - | - | - | - | - |
+| Curvine | forming | - | - | - | - | - | - | - |
+| DevOps AI Toolkit | forming | - | - | - | - | - | - | - |
+| Dexfile | forming | - | - | - | - | - | - | - |
+| Gthulhu | forming | - | - | - | - | - | - | - |
+| Higress | forming | sandbox | - | - | - | - | - | - |
+| KAI Scheduler | forming | sandbox | - | sandbox | sandbox | - | - | - |
+| Kmesh | forming | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ksctl | forming | - | - | - | - | - | - | - |
+| kube-bind | forming | - | - | - | - | - | - | - |
+| KubeElasti | forming | sandbox | - | sandbox | sandbox | - | - | - |
+| llm-d | forming | - | - | - | - | - | - | - |
+| NMstate | forming | - | - | - | - | - | - | - |
+| OpenEverest | forming | sandbox | - | - | - | - | - | - |
+| OptiFlow (AI‑OrchestrateX) | forming | - | - | - | - | - | - | - |
+| Schema Driven Configuration | forming | - | - | - | - | - | - | - |
+| SecureBuild | forming | - | - | - | - | - | - | - |
+| SemaMesh | forming | - | - | - | - | - | - | - |
+| Sermant | forming | sandbox | sandbox | sandbox | sandbox | sandbox | - | - |
+| ServiceRadar | forming | - | - | - | - | - | - | - |
+| Terrascan | forming | - | - | - | - | - | - | - |
+| Brigade | archived | archived | - | - | - | archived | - | - |
+| CNI-Genie | archived | archived | - | - | - | - | - | - |
+| Curiefense | archived | archived | - | - | - | archived | - | - |
+| Curve | archived | archived | - | - | - | archived | - | - |
+| Devstream | archived | archived | - | - | - | archived | - | - |
+| FabEdge | archived | archived | - | - | - | archived | - | - |
+| Fonio | archived | archived | - | - | - | archived | - | - |
+| Keptn | archived | archived | - | - | - | archived | - | - |
+| Krator | archived | archived | - | - | - | archived | - | - |
+| Krustlet | archived | archived | - | - | - | archived | - | - |
+| KubeDL | archived | archived | - | - | - | archived | - | - |
+| Merbridge | archived | archived | - | - | - | archived | - | - |
+| Nocalhost | archived | archived | - | - | - | archived | - | - |
+| Open Service Mesh | archived | archived | - | - | - | archived | - | - |
+| OpenELB | archived | archived | - | - | - | archived | - | - |
+| OpenMetrics | archived | archived | - | - | - | archived | - | - |
+| OpenTracing | archived | archived | - | - | - | archived | - | - |
+| Pravega | archived | archived | - | - | - | archived | - | - |
+| RKT | archived | archived | - | - | - | archived | - | - |
+| sealer | archived | archived | - | - | - | archived | - | - |
+| Service Mesh Interface | archived | archived | - | - | - | archived | - | - |
+| skooner | archived | archived | - | - | - | archived | - | - |
+| SuperEdge | archived | archived | - | - | - | archived | - | - |
+| Teller | archived | archived | - | - | - | archived | - | - |
+| Xline | archived | archived | - | - | - | archived | - | - |

--- a/utilities/audit_project_lifecycle_across_tools/scripts/audit_landscape_status.py
+++ b/utilities/audit_project_lifecycle_across_tools/scripts/audit_landscape_status.py
@@ -34,6 +34,7 @@ CLOMONITOR_SRC_PATH = os.path.join(DATASOURCES_DIR, "clomonitor.yaml")
 MAINTAINERS_SRC_PATH = os.path.join(DATASOURCES_DIR, "project-maintainers.csv")
 DEVSTATS_SRC_PATH = os.path.join(DATASOURCES_DIR, "devstats.html")
 ARTWORK_SRC_PATH = os.path.join(DATASOURCES_DIR, "artwork.md")
+LFX_HEALTH_SRC_PATH = os.path.join(DATASOURCES_DIR, "lfx_insights_health.yaml")
 
 
 def ensure_dirs() -> None:
@@ -143,6 +144,57 @@ def load_pcc_yaml() -> Dict[str, Any]:
         sys.exit(1)
     with open(PCC_YAML_PATH, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def build_lfx_health_map_from_yaml(doc: Dict[str, Any]) -> Dict[str, Tuple[str, str]]:
+    """
+    Map normalized lookup keys -> (health_tier, score_str) from lfx_insights_health.yaml.
+    """
+    out: Dict[str, Tuple[str, str]] = {}
+    for row in doc.get("projects") or []:
+        name = (row.get("name") or "").strip()
+        if not name:
+            continue
+        tier = (row.get("health_tier") or "").strip()
+        os_raw = row.get("overall_score")
+        score_str = str(os_raw) if os_raw is not None else ""
+        extra_slugs: List[str] = []
+        for field in ("pcc_slug", "insights_slug_used"):
+            s = row.get(field)
+            if isinstance(s, str) and s.strip():
+                extra_slugs.append(s.strip())
+        seen_slug: set[str] = set()
+        uniq_slugs: List[str] = []
+        for s in extra_slugs:
+            if s not in seen_slug:
+                seen_slug.add(s)
+                uniq_slugs.append(s)
+
+        keys: set[str] = set()
+        if uniq_slugs:
+            keys.update(
+                generate_aliases_from_landscape(name, {"lfx_slug": uniq_slugs[0]})
+            )
+            for s in uniq_slugs[1:]:
+                keys.update(generate_aliases_from_landscape(name, {"lfx_slug": s}))
+        else:
+            keys.update(generate_aliases_from_landscape(name, {}))
+        for k in keys:
+            if k and k not in out:
+                out[k] = (tier, score_str)
+    return out
+
+
+def load_lfx_health_map() -> Tuple[Dict[str, Tuple[str, str]], bool]:
+    """
+    Load LFX Insights health snapshot if present (from weekly automation).
+    Returns (lookup map, file_was_present).
+    """
+    if not os.path.exists(LFX_HEALTH_SRC_PATH):
+        return {}, False
+    with open(LFX_HEALTH_SRC_PATH, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f.read()) or {}
+    return build_lfx_health_map_from_yaml(doc), True
 
 
 def normalize_name(name: str) -> str:
@@ -541,7 +593,7 @@ def collect_pcc_expected_statuses(pcc_data: Dict[str, Any]) -> List[Tuple[str, s
 
 
 def write_audit_markdown(
-    combined_rows: List[Tuple[str, str, str, str, str, str, str]],
+    combined_rows: List[Tuple[str, str, str, str, str, str, str, str, str]],
 ) -> None:
     lines: List[str] = []
     lines.append(f"# CNCF Project Status Audit")
@@ -550,24 +602,24 @@ def write_audit_markdown(
         lines.append("_No mismatches found between PCC and external sources._")
     else:
         # Column headers hyperlinked to their respective sources for quick reference
-        lines.append("| Project | [PCC status](./pcc_projects.yaml) | [Landscape status](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor status](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers CSV status](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats status](https://devstats.cncf.io/) | [Artwork status](https://github.com/cncf/artwork/blob/main/README.md) |")
-        lines.append("|---|---|---|---|---|---|---|")
+        lines.append("| Project | [PCC status](./pcc_projects.yaml) | [Landscape status](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor status](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers CSV status](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats status](https://devstats.cncf.io/) | [Artwork status](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |")
+        lines.append("|---|---|---|---|---|---|---|---|---|")
         # Sort by PCC status: graduated, incubating, sandbox, forming, archived, prospect; then by project name
         status_order = {"graduated": 0, "incubating": 1, "sandbox": 2, "forming": 3, "archived": 4, "prospect": 5}
-        def sort_key(row: Tuple[str, str, str, str, str, str, str]) -> Tuple[int, str]:
+        def sort_key(row: Tuple[str, str, str, str, str, str, str, str, str]) -> Tuple[int, str]:
             name, pcc_status, *_ = row
             return (status_order.get(pcc_status, 99), name.lower())
         def fmt(v: str) -> str:
             return v if v else "-"
-        for name, pcc_status, landscape_status, cm_status, m_status, d_status, a_status in sorted(combined_rows, key=sort_key):
-            lines.append(f"| {name} | {fmt(pcc_status)} | {fmt(landscape_status)} | {fmt(cm_status)} | {fmt(m_status)} | {fmt(d_status)} | {fmt(a_status)} |")
+        for name, pcc_status, landscape_status, cm_status, m_status, d_status, a_status, lfx_tier, lfx_score in sorted(combined_rows, key=sort_key):
+            lines.append(f"| {name} | {fmt(pcc_status)} | {fmt(landscape_status)} | {fmt(cm_status)} | {fmt(m_status)} | {fmt(d_status)} | {fmt(a_status)} | {fmt(lfx_tier)} | {fmt(lfx_score)} |")
 
     with open(AUDIT_OUTPUT_PATH, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
 
 
 def write_full_status_markdown(
-    all_rows: List[Tuple[str, str, str, str, str, str, str]],
+    all_rows: List[Tuple[str, str, str, str, str, str, str, str, str]],
 ) -> None:
     """
     Write a full report with anomalies first, then all projects grouped by PCC category
@@ -575,8 +627,8 @@ def write_full_status_markdown(
     """
     # Compute anomalies: include projects with ANY missing value ('-' after formatting) OR
     # any external source present and different from PCC
-    anomalies: List[Tuple[str, str, str, str, str, str, str]] = []
-    for name, pcc_status, l_status, cm_status, m_status, d_status, a_status in all_rows:
+    anomalies: List[Tuple[str, str, str, str, str, str, str, str, str]] = []
+    for name, pcc_status, l_status, cm_status, m_status, d_status, a_status, lfx_tier, lfx_score in all_rows:
         norm_pcc = normalize_status(pcc_status)
         missing_any = (l_status == "-") or (not cm_status) or (not m_status) or (not d_status) or (not a_status)
         differs_any = any([
@@ -587,9 +639,9 @@ def write_full_status_markdown(
             (a_status and normalize_status(a_status) != norm_pcc),
         ])
         if missing_any or differs_any:
-            anomalies.append((name, pcc_status, l_status, cm_status, m_status, d_status, a_status))
+            anomalies.append((name, pcc_status, l_status, cm_status, m_status, d_status, a_status, lfx_tier, lfx_score))
 
-    def section(title: str, rows: List[Tuple[str, str, str, str, str, str, str]]) -> List[str]:
+    def section(title: str, rows: List[Tuple[str, str, str, str, str, str, str, str, str]]) -> List[str]:
         out: List[str] = []
         out.append(f"## {title}")
         out.append("")
@@ -597,18 +649,18 @@ def write_full_status_markdown(
             out.append("_No entries._")
             out.append("")
             return out
-        out.append("| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) |")
-        out.append("|---|---|---|---|---|---|---|")
+        out.append("| Project | PCC | [Landscape](https://github.com/cncf/landscape/blob/master/landscape.yml) | [CLOMonitor](https://github.com/cncf/clomonitor/blob/main/data/cncf.yaml) | [Maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) | [DevStats](https://devstats.cncf.io/) | [Artwork](https://github.com/cncf/artwork/blob/main/README.md) | [Insights Health](../datasources/lfx_insights_health.yaml) | [Health Score](../datasources/lfx_insights_health.yaml) |")
+        out.append("|---|---|---|---|---|---|---|---|---|")
         def fmt(v: str) -> str:
             return v if v else "-"
-        for name, pcc_status, l_status, cm_status, m_status, d_status, a_status in rows:
-            out.append(f"| {name} | {fmt(pcc_status)} | {fmt(l_status)} | {fmt(cm_status)} | {fmt(m_status)} | {fmt(d_status)} | {fmt(a_status)} |")
+        for name, pcc_status, l_status, cm_status, m_status, d_status, a_status, lfx_tier, lfx_score in rows:
+            out.append(f"| {name} | {fmt(pcc_status)} | {fmt(l_status)} | {fmt(cm_status)} | {fmt(m_status)} | {fmt(d_status)} | {fmt(a_status)} | {fmt(lfx_tier)} | {fmt(lfx_score)} |")
         out.append("")
         return out
 
     # Sort helpers (match anomalies table order)
     status_order = {"graduated": 0, "incubating": 1, "sandbox": 2, "forming": 3, "archived": 4, "prospect": 5}
-    def status_then_name(row: Tuple[str, str, str, str, str, str, str]) -> Tuple[int, str]:
+    def status_then_name(row: Tuple[str, str, str, str, str, str, str, str, str]) -> Tuple[int, str]:
         name, pcc_status, *_ = row
         return (status_order.get(normalize_status(pcc_status), 99), name.lower())
 
@@ -616,7 +668,7 @@ def write_full_status_markdown(
     anomalies_sorted = sorted(anomalies, key=status_then_name)
 
     # Group all by PCC category (include forming, archived, and prospect too)
-    by_cat: Dict[str, List[Tuple[str, str, str, str, str, str, str]]] = {
+    by_cat: Dict[str, List[Tuple[str, str, str, str, str, str, str, str, str]]] = {
         "graduated": [],
         "incubating": [],
         "sandbox": [],
@@ -663,10 +715,11 @@ def main() -> None:
     maintainers_map = build_foundation_status_map(maintainers_csv)
     devstats_map = build_devstats_status_map(devstats_html)
     artwork_map = build_artwork_status_map(artwork_readme)
+    lfx_map, _ = load_lfx_health_map()
     expected = collect_pcc_expected_statuses(pcc)
 
-    combined_rows: List[Tuple[str, str, str, str, str, str, str]] = []
-    all_rows: List[Tuple[str, str, str, str, str, str, str]] = []
+    combined_rows: List[Tuple[str, str, str, str, str, str, str, str, str]] = []
+    all_rows: List[Tuple[str, str, str, str, str, str, str, str, str]] = []
     for name, pcc_status in expected:
         norm_pcc = normalize_status(pcc_status)
         # Build multiple query keys for Landscape lookup
@@ -722,7 +775,18 @@ def main() -> None:
         d_status = normalize_status(d_status_raw) if d_status_raw else ""
         a_status = normalize_status(a_status_raw) if a_status_raw else ""
 
-        all_rows.append((name, norm_pcc, l_status, cm_status, m_status, d_status, a_status))
+        lfx_tier_raw = ""
+        lfx_score_raw = ""
+        for k in query_keys:
+            if k in lfx_map:
+                t, s = lfx_map[k]
+                lfx_tier_raw = t or ""
+                lfx_score_raw = s or ""
+                break
+        lfx_tier = (lfx_tier_raw or "").strip()
+        lfx_score = (lfx_score_raw or "").strip()
+
+        all_rows.append((name, norm_pcc, l_status, cm_status, m_status, d_status, a_status, lfx_tier, lfx_score))
 
         # Anomaly criteria:
         # - Any missing value in any source (displayed as '-' later; Landscape missing is already '-')
@@ -735,7 +799,7 @@ def main() -> None:
         any_missing = (l_status == "-") or (not cm_status) or (not m_status) or (not d_status) or (not a_status)
 
         if any_missing or landscape_mismatch or clomonitor_mismatch or maintainers_mismatch or devstats_mismatch or artwork_mismatch:
-            combined_rows.append((name, norm_pcc, l_status, cm_status, m_status, d_status, a_status))
+            combined_rows.append((name, norm_pcc, l_status, cm_status, m_status, d_status, a_status, lfx_tier, lfx_score))
 
     write_audit_markdown(combined_rows)
     write_full_status_markdown(all_rows)

--- a/utilities/audit_project_lifecycle_across_tools/scripts/fetch_lfx_insights_health.py
+++ b/utilities/audit_project_lifecycle_across_tools/scripts/fetch_lfx_insights_health.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Fetch LFX Insights health tier (and optional numeric score) for CNCF projects listed in
+datasources/pcc_projects.yaml.
+
+Uses the public badge endpoint (302 to shields.io with message=<tier>) — no LFX_TOKEN.
+Project keys match Insights `/project/{slug}` using the PCC `slug` field when present; when
+absent, a slug is derived from the PCC `name` (same string shown in audit "Project" column).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qs, unquote, urlparse
+
+import requests
+
+try:
+    import yaml  # type: ignore
+except Exception:
+    print("Missing dependency: PyYAML. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+REPO_ROOT = os.getcwd()
+DATASOURCES_DIR = os.path.join(REPO_ROOT, "datasources")
+PCC_PATH = os.path.join(DATASOURCES_DIR, "pcc_projects.yaml")
+OUTPUT_PATH = os.path.join(DATASOURCES_DIR, "lfx_insights_health.yaml")
+
+BADGE_URL = "https://insights.linuxfoundation.org/api/badge/health-score"
+PROJECT_PAGE_URL = "https://insights.linuxfoundation.org/project/{slug}"
+
+SESSION = requests.Session()
+SESSION.headers.update(
+    {
+        "User-Agent": "cncf-automation/lfx-insights-health (+github actions)",
+        "Accept": "text/html,application/json",
+    }
+)
+
+OVERALL_SCORE_RE = re.compile(r'overall-score="(\d+)"')
+SLEEP_SECONDS = 0.35
+
+
+def slugify_from_name(name: str) -> str:
+    """Fallback slug when PCC has no Slug (forming / some archived)."""
+    s = re.sub(r"\([^)]*\)", "", name or "")
+    s = s.lower().strip()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    return s
+
+
+def iter_pcc_projects(
+    pcc: Dict[str, Any], max_projects: Optional[int] = None
+) -> List[Tuple[str, Optional[str], str]]:
+    """
+    Yields (display_name, pcc_slug_or_none, origin) for each project row we try to match
+    in Insights. Order: Graduated, Incubating, Sandbox, forming, archived.
+    """
+    out: List[Tuple[str, Optional[str], str]] = []
+    categories = pcc.get("categories") or {}
+    for cat in ("Graduated", "Incubating", "Sandbox"):
+        for item in categories.get(cat) or []:
+            name = (item.get("name") or "").strip()
+            if not name:
+                continue
+            slug = item.get("slug")
+            if isinstance(slug, str):
+                slug = slug.strip() or None
+            out.append((name, slug, f"category:{cat}"))
+    for item in pcc.get("forming_projects") or []:
+        name = (item.get("name") or "").strip()
+        if not name:
+            continue
+        slug = item.get("slug")
+        if isinstance(slug, str):
+            slug = slug.strip() or None
+        out.append((name, slug, "forming"))
+    for item in pcc.get("archived_projects") or []:
+        name = (item.get("name") or "").strip()
+        if not name:
+            continue
+        slug = item.get("slug")
+        if isinstance(slug, str):
+            slug = slug.strip() or None
+        out.append((name, slug, "archived"))
+    if max_projects is not None:
+        return out[: max(0, max_projects)]
+    return out
+
+
+def resolve_slugs_to_try(name: str, pcc_slug: Optional[str]) -> List[str]:
+    """Insights is case-sensitive per project; try PCC slug first, then derived."""
+    seen: set[str] = set()
+    ordered: List[str] = []
+    if pcc_slug:
+        for s in (pcc_slug, pcc_slug.lower()):
+            if s and s not in seen:
+                seen.add(s)
+                ordered.append(s)
+    derived = slugify_from_name(name)
+    if derived and derived not in seen:
+        ordered.append(derived)
+    return ordered
+
+
+def tier_from_badge_head(slug: str) -> Tuple[Optional[str], int]:
+    """
+    Returns (tier_label, http_status) for the badge HEAD request.
+    tier_label is parsed from shields redirect Location (message=...).
+    """
+    try:
+        r = SESSION.head(
+            BADGE_URL,
+            params={"project": slug},
+            allow_redirects=False,
+            timeout=45,
+        )
+    except requests.RequestException as e:
+        print(f"  badge HEAD error for slug={slug!r}: {e}", file=sys.stderr)
+        return None, 0
+
+    if r.status_code == 302 and r.headers.get("Location"):
+        loc = r.headers["Location"]
+        q = parse_qs(urlparse(loc).query)
+        raw = (q.get("message") or [None])[0]
+        if raw:
+            return unquote(raw), r.status_code
+    return None, r.status_code
+
+
+def overall_score_from_project_page(slug: str) -> Optional[int]:
+    """Fetch SSR project page and read overall-score=\"N\" if present."""
+    url = PROJECT_PAGE_URL.format(slug=requests.utils.quote(slug, safe=""))
+    try:
+        r = SESSION.get(url, timeout=45)
+    except requests.RequestException:
+        return None
+    if r.status_code != 200:
+        return None
+    m = OVERALL_SCORE_RE.search(r.text)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+
+def fetch_one(name: str, pcc_slug: Optional[str]) -> Dict[str, Any]:
+    slugs = resolve_slugs_to_try(name, pcc_slug)
+    row: Dict[str, Any] = {
+        "name": name,
+        "pcc_slug": pcc_slug,
+        "insights_slug_used": None,
+        "health_tier": None,
+        "overall_score": None,
+        "error": None,
+    }
+    last_status: Optional[int] = None
+    for slug in slugs:
+        tier, status = tier_from_badge_head(slug)
+        last_status = status
+        if tier:
+            row["insights_slug_used"] = slug
+            row["health_tier"] = tier
+            time.sleep(SLEEP_SECONDS)
+            row["overall_score"] = overall_score_from_project_page(slug)
+            return row
+        time.sleep(SLEEP_SECONDS)
+
+    row["error"] = "not_found"
+    if last_status is not None:
+        row["http_status_last"] = last_status
+    return row
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch LFX Insights health scores from PCC project list.")
+    parser.add_argument(
+        "--max-projects",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Only process the first N projects (for testing).",
+    )
+    args = parser.parse_args()
+
+    os.makedirs(DATASOURCES_DIR, exist_ok=True)
+    if not os.path.isfile(PCC_PATH):
+        print(f"Error: {PCC_PATH} not found. Run PCC sync or checkout the repo with datasources.", file=sys.stderr)
+        sys.exit(1)
+
+    with open(PCC_PATH, "r", encoding="utf-8") as f:
+        pcc = yaml.safe_load(f.read())
+
+    projects_in = iter_pcc_projects(pcc, max_projects=args.max_projects)
+    results: List[Dict[str, Any]] = []
+    for i, (name, pcc_slug, _origin) in enumerate(projects_in):
+        print(f"[{i + 1}/{len(projects_in)}] {name!r} ...", flush=True)
+        results.append(fetch_one(name, pcc_slug))
+        time.sleep(SLEEP_SECONDS)
+
+    out_doc: Dict[str, Any] = {
+        "source": "LFX Insights (badge API + project page SSR)",
+        "pcc_source_file": "datasources/pcc_projects.yaml",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "projects": results,
+    }
+
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        yaml.safe_dump(out_doc, f, sort_keys=False, allow_unicode=True)
+
+    ok = sum(1 for r in results if r.get("health_tier"))
+    missing = sum(1 for r in results if r.get("error") == "not_found")
+    print(f"Wrote {OUTPUT_PATH} — {ok} with tier, {missing} not found, {len(results)} total")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Introduced a new section in the README for Project Status Audit, detailing the cross-checking of CNCF project lifecycle data against multiple sources, including optional LFX Insights health metrics.
- Updated the audit scripts to incorporate LFX Insights health tier and score, enhancing the audit reports with additional health data.
- Modified the output markdown files to include columns for Insights Health and Health Score, providing a more comprehensive view of project statuses.
- Adjusted the workflow configuration to support the integration of LFX Insights data.

This update improves the visibility of project health and status across various datasets.