### PR TITLE
feat(notes.cncf.io): add LFX auth support via Dex OIDC connector

### DIFF
--- a/ci/cluster/services/apps/dex.yaml
+++ b/ci/cluster/services/apps/dex.yaml
@@ -28,6 +28,8 @@ spec:
         envFrom:
         - secretRef:
             name: github-oidc-client-credentials
+        - secretRef:
+            name: lfx-oidc-client-credentials
         config:
           issuer: "https://auth.services.cncf.io/dex"
           oauth2:
@@ -64,6 +66,20 @@ spec:
               redirectURI: https://auth.services.cncf.io/dex/callback
               orgs:
                 - name: cncf
+          - type: oidc
+            id: lfx
+            name: LFX
+            config:
+              issuer: https://sso.linuxfoundation.org/
+              clientID: $LFX_CLIENT_ID
+              clientSecret: $LFX_CLIENT_SECRET
+              redirectURI: https://auth.services.cncf.io/dex/callback
+              scopes:
+                - openid
+                - profile
+                - email
+              getUserInfo: true
+              insecureSkipEmailVerified: true
   destination:
     server: https://kubernetes.default.svc
     namespace: auth

--- a/ci/cluster/services/manifests/external-secrets/lfx-oidc-client-credentials.yaml
+++ b/ci/cluster/services/manifests/external-secrets/lfx-oidc-client-credentials.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: lfx-oidc-client-credentials
+  namespace: auth
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: oci-secret-store
+  target:
+    name: lfx-oidc-client-credentials
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: lfx-oidc-client-credentials


### PR DESCRIPTION
## Summary

Closes #110

Adds LFX (Linux Foundation) as a second authentication connector in Dex, the OIDC broker that backs notes.cncf.io. Previously, access was limited to members of the CNCF GitHub org. With this change, anyone with an LFX account can log in.

## Changes

- **`ci/cluster/services/apps/dex.yaml`** - Added LFX OIDC connector (`type: oidc`, issuer: `https://sso.linuxfoundation.org/`) alongside the existing GitHub connector. Credentials are injected via env vars from the new secret.
- **`ci/cluster/services/manifests/external-secrets/lfx-oidc-client-credentials.yaml`** - New ExternalSecret to pull `LFX_CLIENT_ID` and `LFX_CLIENT_SECRET` from OCI Vault into the `auth` namespace, following the same pattern as `github-oidc-client-credentials.yaml`.

## Pre-deploy Requirements (infra team action needed)

Before this can be deployed, the CNCF infra team needs to:

1. Register an OAuth2 application with LFX Identity at `https://sso.linuxfoundation.org/` with redirect URI: `https://auth.services.cncf.io/dex/callback`
2. Store the resulting credentials in OCI Vault under key `lfx-oidc-client-credentials` with fields:
   - `LFX_CLIENT_ID`
   - `LFX_CLIENT_SECRET`

**Once the Vault secret is populated, the ExternalSecret controller will sync it and ArgoCD will apply the updated Dex config automatically.**

## Testing

After deployment:
- [ ] Both **GitHub** and **LFX** login options appear on notes.cncf.io
- [ ] LFX login works end-to-end with a valid LFX account
- [ ] Existing GitHub login (cncf org members) continues to work