### PR TITLE
fix: close resp.Body immediately inside loop in SearchTOCIssues

### DIFF
--- a/utilities/dot-project/bootstrap_sources.go
+++ b/utilities/dot-project/bootstrap_sources.go
@@ -655,9 +655,16 @@ func SearchTOCIssues(projectName, orgName, token string, client *http.Client, ba
 		if err != nil {
 			continue
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			continue
+		}
+
+		// Ensure the response body is closed after we're done reading it.
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
 			continue
 		}
 
@@ -669,7 +676,7 @@ func SearchTOCIssues(projectName, orgName, token string, client *http.Client, ba
 				Number  int    `json:"number"`
 			} `json:"items"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&searchResult); err != nil {
+		if err := json.Unmarshal(body, &searchResult); err != nil {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Fixes #294

`defer resp.Body.Close()` was called inside a `for` loop in `SearchTOCIssues`. Since `defer` runs at function return (not loop iteration end), all response bodies remain open until the function exits, causing connection leaks when multiple queries are executed.

## Changes

- Replaced `defer resp.Body.Close()` with immediate `resp.Body.Close()` calls
- Read body with `io.ReadAll` before closing
- Changed `json.NewDecoder(resp.Body).Decode()` to `json.Unmarshal(body, ...)` for cleaner resource management

## Testing

- All existing tests pass (`TestSearchTOCIssues`)
- No new dependencies added