### PR TITLE
Add CLOMonitor URL anomaly reporting to landscape data integrity audit

### DIFF
--- a/.github/workflows/landscape-data-content-auditor.yml
+++ b/.github/workflows/landscape-data-content-auditor.yml
@@ -69,6 +69,7 @@ jobs:
             - `audit/landscape_data_integrity_audit/landscape_source_diff.md`
             - `audit/landscape_data_integrity_audit/landscape_source_diff.json`
             - `audit/landscape_data_integrity_audit/repo_url_pcc_landscape_anomalies.md`
+            - `audit/landscape_data_integrity_audit/repo_url_landscape_clomonitor_anomalies.md`
 
             Data sources used:
             - `datasources/landscape.yml`
@@ -79,3 +80,4 @@ jobs:
             utilities/audit_project_lifecycle_across_tools/audit/landscape_data_integrity_audit/landscape_source_diff.md
             utilities/audit_project_lifecycle_across_tools/audit/landscape_data_integrity_audit/landscape_source_diff.json
             utilities/audit_project_lifecycle_across_tools/audit/landscape_data_integrity_audit/repo_url_pcc_landscape_anomalies.md
+            utilities/audit_project_lifecycle_across_tools/audit/landscape_data_integrity_audit/repo_url_landscape_clomonitor_anomalies.md

--- a/utilities/audit_project_lifecycle_across_tools/README.md
+++ b/utilities/audit_project_lifecycle_across_tools/README.md
@@ -26,7 +26,7 @@ This utility generates a canonical list of CNCF project statuses from the LFX PC
 | `scripts/fetch_lfx_insights_health.py` | Builds `lfx_insights_health.yaml` from Insights project pages + badge (no token; archived status from page) |
 | `scripts/audit_landscape_status.py` | Compares sources and writes `audit/*.md` |
 | `scripts/landscape_source_diff.py` | Compare `landscape.yml` to `pcc_projects.yaml` + `clomonitor.yaml`; flags landscape drift and PCC↔CLOMonitor disagreements → `audit/landscape_data_integrity_audit/landscape_source_diff.{md,json}` |
-| `scripts/repo_url_landscape_healthcheck.py` | Build PCC-focused repo URL anomalies from `landscape_source_diff.json` (`repo_url` findings) using `curl` checks, GitHub org-match alignment, and final destination comparison → `audit/landscape_data_integrity_audit/repo_url_pcc_landscape_anomalies.md` |
+| `scripts/repo_url_landscape_healthcheck.py` | Build both PCC-focused and CLOMonitor-focused repo URL anomalies from `landscape_source_diff.json` (`repo_url` findings) using `curl` checks, GitHub org-match alignment, and final destination comparison → `audit/landscape_data_integrity_audit/repo_url_pcc_landscape_anomalies.md`, `audit/landscape_data_integrity_audit/repo_url_landscape_clomonitor_anomalies.md` |
 | `.github/workflows/sync-pcc-and-audit-statuses.yml` | Manual workflow: PCC + snapshots + audit → PR |
 | `.github/workflows/landscape-data-content-auditor.yml` | Manual workflow: runs both landscape audit scripts; opens a PR only if `audit/landscape_data_integrity_audit/*.{md,json}` change (no `LFX_TOKEN`) |
 | `.github/workflows/sync-lfx-insights-health.yml` | Weekly (Sunday UTC) + manual: refresh `lfx_insights_health.yaml` → PR |
@@ -37,6 +37,7 @@ This utility generates a canonical list of CNCF project statuses from the LFX PC
 | `audit/all_statuses.md` | Generated full table |
 | `audit/landscape_data_integrity_audit/landscape_source_diff.{md,json}` | Generated landscape vs PCC / CLOMonitor diff |
 | `audit/landscape_data_integrity_audit/repo_url_pcc_landscape_anomalies.md` | Generated PCC-focused repo URL anomalies from `landscape_source_diff.json` |
+| `audit/landscape_data_integrity_audit/repo_url_landscape_clomonitor_anomalies.md` | Generated CLOMonitor-focused repo URL anomalies from `landscape_source_diff.json` |
 
 ## Data sources
 
@@ -67,7 +68,7 @@ This utility generates a canonical list of CNCF project statuses from the LFX PC
 
 1. Ensure `datasources/landscape.yml`, `datasources/pcc_projects.yaml`, and `datasources/clomonitor.yaml` are present on the default branch (typically refreshed by the PCC sync workflow).
 2. **Actions → “Landscape Data Content Auditor” → Run workflow**
-3. If outputs under `audit/landscape_data_integrity_audit/` change, the workflow opens or updates a PR with only those files (`landscape_source_diff.{md,json}`, `repo_url_pcc_landscape_anomalies.md`).
+3. If outputs under `audit/landscape_data_integrity_audit/` change, the workflow opens or updates a PR with only those files (`landscape_source_diff.{md,json}`, `repo_url_pcc_landscape_anomalies.md`, `repo_url_landscape_clomonitor_anomalies.md`).
 
 ## Run locally
 
@@ -96,12 +97,16 @@ cd utilities/audit_project_lifecycle_across_tools
 python scripts/landscape_source_diff.py
 ```
 
-**Repo URL healthcheck from source diff** (requires `landscape_source_diff.json`; no `LFX_TOKEN`):
+**Repo URL anomaly reports from source diff** (requires `landscape_source_diff.json`; no `LFX_TOKEN`):
 
 ```bash
 cd utilities/audit_project_lifecycle_across_tools
 python scripts/repo_url_landscape_healthcheck.py
 ```
+
+Generates:
+- `audit/landscape_data_integrity_audit/repo_url_pcc_landscape_anomalies.md`
+- `audit/landscape_data_integrity_audit/repo_url_landscape_clomonitor_anomalies.md`
 
 **Audit reports:**
 
@@ -120,5 +125,6 @@ Outputs: `audit/status_audit.md`, `audit/all_statuses.md`, and any missing `data
 - PCC entries with `status: Formation - Disengaged` are excluded from audit outputs.
 - PCC entries with `status: Formation - Engaged` are treated as **Forming** in the audit.
 - Landscape matching uses aliases (parentheticals, suffix trimming, Unicode normalization, `lfx_slug`, hyphen/space variants) — see `audit_landscape_status.py`.
+- In `repo_url_landscape_clomonitor_anomalies.md`, archived projects are intentionally ignored because CLOMonitor removes archived projects quickly.
 - DevStats parsing uses page row headings (“Graduated”, “Incubating”, “Sandbox”, “Archived”).
 - LFX Insights fetch loads each project’s Insights **page** first. If the page shows the project as **Archived** there, we store **Insights Health** = `Archived` and no score (the public badge alone can still show another label and is not used in that case). URL slugs are tried as: slug derived from PCC **name** (same as the audit “Project” column), then PCC **`slug`** when it differs (e.g. CubeFS → `chubaofs`).

--- a/utilities/audit_project_lifecycle_across_tools/audit/landscape_data_integrity_audit/repo_url_landscape_clomonitor_anomalies.md
+++ b/utilities/audit_project_lifecycle_across_tools/audit/landscape_data_integrity_audit/repo_url_landscape_clomonitor_anomalies.md
@@ -1,0 +1,11 @@
+# Repo URL anomalies for CLOMonitor (Landscape vs CLOMonitor)
+
+Generated from `landscape_source_diff.json` (`field = repo_url`) with `curl` URL checks.
+
+Rule: when both URLs are GitHub and org/owner matches, repo path differences are treated as aligned.
+This report includes only non-aligned (anomalous) CLOMonitor vs Landscape rows.
+
+| Project | Maturity | CLOMonitor URL | CLOMonitor | Landscape URL | Landscape | Org match | Same final destination | Result | Note |
+|---|---|---|---|---|---|---|---|---|---|
+| KubeFleet | sandbox | https://github.com/Azure/fleet | ✅ 200 | https://github.com/kubefleet-dev/kubefleet | ✅ 200 | No | No | Mismatch | Different final destinations: CLOMonitor `https://github.com/Azure/fleet` vs Landscape `https://github.com/kubefleet-dev/kubefleet`. |
+| SpinKube | sandbox | https://github.com/spinkube/documentation | ✅ 200 | https://github.com/spinframework/spin-operator | ✅ 200 | No | No | Mismatch | Different final destinations: CLOMonitor `https://github.com/spinframework/spinkube-docs` vs Landscape `https://github.com/spinframework/spin-operator`. |

--- a/utilities/audit_project_lifecycle_across_tools/scripts/repo_url_landscape_healthcheck.py
+++ b/utilities/audit_project_lifecycle_across_tools/scripts/repo_url_landscape_healthcheck.py
@@ -4,7 +4,7 @@ Generate repo URL healthcheck markdown from landscape_source_diff.json.
 
 Policy:
 - Input candidates are repo_url findings from landscape_source_diff.json.
-- If PCC and Landscape GitHub org/owner match, repo-level mismatch is ignored.
+- If compared source and Landscape GitHub org/owner match, repo-level mismatch is ignored.
 - Otherwise compare reachability and final redirect destination.
 """
 
@@ -24,7 +24,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 AUDIT_ROOT = os.path.dirname(SCRIPT_DIR)
 OUTPUT_DIR = os.path.join(AUDIT_ROOT, "audit", "landscape_data_integrity_audit")
 DEFAULT_SOURCE_JSON = os.path.join(OUTPUT_DIR, "landscape_source_diff.json")
-DEFAULT_OUTPUT_MD = os.path.join(OUTPUT_DIR, "repo_url_pcc_landscape_anomalies.md")
+DEFAULT_OUTPUT_PCC_MD = os.path.join(OUTPUT_DIR, "repo_url_pcc_landscape_anomalies.md")
+DEFAULT_OUTPUT_CLO_MD = os.path.join(OUTPUT_DIR, "repo_url_landscape_clomonitor_anomalies.md")
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,7 @@ class RepoRow:
     project: str
     maturity: str
     pcc_url: str
+    clomonitor_url: str
     landscape_url: str
 
 
@@ -53,7 +55,7 @@ def load_repo_rows(source_json_path: str) -> List[RepoRow]:
         data: Dict[str, Any] = json.load(f)
 
     rows: List[RepoRow] = []
-    seen: Set[Tuple[str, str, str, str]] = set()
+    seen: Set[Tuple[str, str, str, str, str]] = set()
     for project in data.get("projects", []):
         name = str(project.get("name") or "").strip()
         maturity = str(project.get("maturity") or "").strip()
@@ -61,8 +63,9 @@ def load_repo_rows(source_json_path: str) -> List[RepoRow]:
             if finding.get("field") != "repo_url":
                 continue
             pcc_url = _normalize_cell(finding.get("pcc"))
+            clomonitor_url = _normalize_cell(finding.get("clomonitor"))
             landscape_url = _normalize_cell(finding.get("landscape"))
-            key = (name, maturity, pcc_url, landscape_url)
+            key = (name, maturity, pcc_url, clomonitor_url, landscape_url)
             if key in seen:
                 continue
             seen.add(key)
@@ -71,6 +74,7 @@ def load_repo_rows(source_json_path: str) -> List[RepoRow]:
                     project=name,
                     maturity=maturity,
                     pcc_url=pcc_url,
+                    clomonitor_url=clomonitor_url,
                     landscape_url=landscape_url,
                 )
             )
@@ -161,54 +165,50 @@ def check_url(url: str, timeout_seconds: int = 20) -> UrlCheck:
     )
 
 
-def render_markdown(rows: Iterable[RepoRow]) -> str:
-    lines = [
-        "# Repo URL anomalies for PCC (Landscape vs PCC)",
-        "",
-        "Generated from `landscape_source_diff.json` (`field = repo_url`) with `curl` URL checks.",
-        "",
-        "Rule: when both URLs are GitHub and org/owner matches, repo path differences are treated as aligned.",
-        "This report includes only non-aligned (anomalous) PCC vs Landscape rows.",
-        "",
-        "| Project | Maturity | PCC URL | PCC | Landscape URL | Landscape | Org match | Same final destination | Result | Note |",
-        "|---|---|---|---|---|---|---|---|---|---|",
-    ]
+def _build_rows(
+    rows: Iterable[RepoRow],
+    source_label: str,
+    ignore_archived: bool = False,
+) -> List[Dict[str, str]]:
     rendered_rows: List[Dict[str, str]] = []
     for row in rows:
-        pcc = check_url(row.pcc_url)
+        if ignore_archived and row.maturity.lower() == "archived":
+            continue
+        source_url = row.pcc_url if source_label == "PCC" else row.clomonitor_url
+        source = check_url(source_url)
         land = check_url(row.landscape_url)
-        pcc_owner = _github_owner(row.pcc_url)
+        source_owner = _github_owner(source_url)
         land_owner = _github_owner(row.landscape_url)
-        org_match = bool(pcc_owner and land_owner and pcc_owner == land_owner)
+        org_match = bool(source_owner and land_owner and source_owner == land_owner)
 
-        pcc_final_norm = _normalize_url(pcc.final_url)
+        source_final_norm = _normalize_url(source.final_url)
         land_final_norm = _normalize_url(land.final_url)
         same_final_value = "N/A"
         same_final_bool = False
-        if pcc.ok and land.ok and pcc_final_norm != "—" and land_final_norm != "—":
-            same_final_bool = pcc_final_norm == land_final_norm
+        if source.ok and land.ok and source_final_norm != "—" and land_final_norm != "—":
+            same_final_bool = source_final_norm == land_final_norm
             same_final_value = "Yes" if same_final_bool else "No"
 
-        if row.pcc_url == "—" or row.landscape_url == "—":
+        if source_url == "—" or row.landscape_url == "—":
             result = "Missing URL"
             note = "One side is missing."
         elif org_match:
             result = "Aligned (org match)"
-            note = f"GitHub owner `{pcc_owner}` matches; repo path ignored."
+            note = f"GitHub owner `{source_owner}` matches; repo path ignored."
         elif same_final_bool:
-            result = "Aligned (same final URL)"
+            result = "Aligned (same final destination)"
             note = "URLs converge to same effective destination."
         elif same_final_value == "No":
             result = "Mismatch"
             note = (
                 "Different final destinations: "
-                f"PCC `{pcc.final_url}` vs Landscape `{land.final_url}`."
+                f"{source_label} `{source.final_url}` vs Landscape `{land.final_url}`."
             )
         else:
             result = "URL error"
             note = (
                 "At least one URL is not reachable: "
-                f"PCC `{pcc.status_text}`, Landscape `{land.status_text}`."
+                f"{source_label} `{source.status_text}`, Landscape `{land.status_text}`."
             )
 
         aligned_by_policy = org_match or same_final_bool
@@ -217,8 +217,8 @@ def render_markdown(rows: Iterable[RepoRow]) -> str:
                 {
                     "project": row.project,
                     "maturity": row.maturity,
-                    "pcc_url": row.pcc_url,
-                    "pcc_status": pcc.status_text,
+                    "source_url": source_url,
+                    "source_status": source.status_text,
                     "landscape_url": row.landscape_url,
                     "landscape_status": land.status_text,
                     "org_match": "Yes" if org_match else "No",
@@ -231,9 +231,30 @@ def render_markdown(rows: Iterable[RepoRow]) -> str:
     # Keep "Same final destination = No" rows at the top, then N/A, then Yes.
     sort_rank = {"No": 0, "N/A": 1, "Yes": 2}
     rendered_rows.sort(key=lambda r: (sort_rank.get(r["same_final"], 3), r["project"].lower()))
+    return rendered_rows
+
+
+def render_markdown(rows: Iterable[RepoRow], source_label: str) -> str:
+    source_title = "PCC" if source_label == "PCC" else "CLOMonitor"
+    lines = [
+        f"# Repo URL anomalies for {source_title} (Landscape vs {source_title})",
+        "",
+        "Generated from `landscape_source_diff.json` (`field = repo_url`) with `curl` URL checks.",
+        "",
+        "Rule: when both URLs are GitHub and org/owner matches, repo path differences are treated as aligned.",
+        f"This report includes only non-aligned (anomalous) {source_title} vs Landscape rows.",
+        "",
+        f"| Project | Maturity | {source_title} URL | {source_title} | Landscape URL | Landscape | Org match | Same final destination | Result | Note |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    rendered_rows = _build_rows(
+        rows,
+        source_label=source_label,
+        ignore_archived=(source_label == "CLOMonitor"),
+    )
     for r in rendered_rows:
         lines.append(
-            f"| {r['project']} | {r['maturity']} | {r['pcc_url']} | {r['pcc_status']} | "
+            f"| {r['project']} | {r['maturity']} | {r['source_url']} | {r['source_status']} | "
             f"{r['landscape_url']} | {r['landscape_status']} | {r['org_match']} | "
             f"{r['same_final']} | {r['result']} | {r['note']} |"
         )
@@ -243,7 +264,7 @@ def render_markdown(rows: Iterable[RepoRow]) -> str:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Generate repo_url_pcc_landscape_anomalies.md from "
+            "Generate repo URL anomaly reports from "
             "audit/landscape_data_integrity_audit/landscape_source_diff.json"
         )
     )
@@ -253,9 +274,14 @@ def parse_args() -> argparse.Namespace:
         help="Path to landscape_source_diff.json",
     )
     parser.add_argument(
-        "--output-md",
-        default=DEFAULT_OUTPUT_MD,
-        help="Path to output markdown report",
+        "--output-pcc-md",
+        default=DEFAULT_OUTPUT_PCC_MD,
+        help="Path to output PCC-vs-Landscape anomalies markdown report",
+    )
+    parser.add_argument(
+        "--output-clomonitor-md",
+        default=DEFAULT_OUTPUT_CLO_MD,
+        help="Path to output CLOMonitor-vs-Landscape anomalies markdown report",
     )
     return parser.parse_args()
 
@@ -263,7 +289,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     source_json = os.path.abspath(args.source_json)
-    output_md = os.path.abspath(args.output_md)
+    output_pcc_md = os.path.abspath(args.output_pcc_md)
+    output_clo_md = os.path.abspath(args.output_clomonitor_md)
 
     if not os.path.isfile(source_json):
         print(
@@ -274,13 +301,20 @@ def main() -> int:
         return 1
 
     rows = load_repo_rows(source_json)
-    body = render_markdown(rows)
-    os.makedirs(os.path.dirname(output_md), exist_ok=True)
-    with open(output_md, "w", encoding="utf-8") as f:
-        f.write(body)
+    pcc_body = render_markdown(rows, source_label="PCC")
+    clo_body = render_markdown(rows, source_label="CLOMonitor")
 
-    print(f"Wrote {output_md}")
-    print(f"Rows: {len(rows)}")
+    os.makedirs(os.path.dirname(output_pcc_md), exist_ok=True)
+    with open(output_pcc_md, "w", encoding="utf-8") as f:
+        f.write(pcc_body)
+
+    os.makedirs(os.path.dirname(output_clo_md), exist_ok=True)
+    with open(output_clo_md, "w", encoding="utf-8") as f:
+        f.write(clo_body)
+
+    print(f"Wrote {output_pcc_md}")
+    print(f"Wrote {output_clo_md}")
+    print(f"Input rows: {len(rows)}")
     return 0
 
 


### PR DESCRIPTION
- Introduced a new report for CLOMonitor-focused repo URL anomalies, generated from `landscape_source_diff.json`.
- Updated the `repo_url_landscape_healthcheck.py` script to handle both PCC and CLOMonitor URLs.
- Enhanced the README documentation to reflect the new anomaly report and its generation process.