### PR TITLE
Add landscape-guard action to support one-way sync from .project to Landscape

### DIFF
--- a/.github/actions/landscape-guard/action.yml
+++ b/.github/actions/landscape-guard/action.yml
@@ -23,9 +23,12 @@ runs:
     # 1. Get the base branch version of landscape.yml
     - name: Fetch base ref
       shell: bash
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        LANDSCAPE_FILE: ${{ inputs.landscape-file }}
       run: |
-        git fetch origin ${{ github.base_ref }} --depth=1
-        git show origin/${{ github.base_ref }}:${{ inputs.landscape-file }} > /tmp/landscape-base.yml
+        git fetch origin "$BASE_REF" --depth=1
+        git show "origin/$BASE_REF:$LANDSCAPE_FILE" > /tmp/landscape-base.yml
 
     # 2. Run the checker script
     - name: Check for managed field changes
@@ -42,7 +45,7 @@ runs:
     # 3. Post PR comment if violations found
     - name: Comment on PR
       if: steps.check.outputs.comment != ''
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/landscape-guard/action.yml
+++ b/.github/actions/landscape-guard/action.yml
@@ -1,0 +1,57 @@
+name: landscape-guard
+description: >
+  Checks landscape.yml PRs for direct modifications to fields managed by
+  dot-project (.project) repos. Posts a warning comment when a project that
+  has adopted .project is edited directly in the landscape.
+
+inputs:
+  github-token:
+    description: "GitHub token for API calls and PR comments"
+    required: true
+  landscape-file:
+    description: "Path to landscape.yml relative to repo root"
+    required: false
+    default: "landscape.yml"
+  fail-on-violation:
+    description: "Set to 'true' to fail the check instead of just warning"
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # 1. Get the base branch version of landscape.yml
+    - name: Fetch base ref
+      shell: bash
+      run: |
+        git fetch origin ${{ github.base_ref }} --depth=1
+        git show origin/${{ github.base_ref }}:${{ inputs.landscape-file }} > /tmp/landscape-base.yml
+
+    # 2. Run the checker script
+    - name: Check for managed field changes
+      id: check
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        LANDSCAPE_BASE: /tmp/landscape-base.yml
+        LANDSCAPE_PR: ${{ inputs.landscape-file }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        FAIL_ON_VIOLATION: ${{ inputs.fail-on-violation }}
+      run: python3 ${{ github.action_path }}/check.py
+
+    # 3. Post PR comment if violations found
+    - name: Comment on PR
+      if: steps.check.outputs.comment != ''
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+          const comment = fs.readFileSync('/tmp/landscape-guard-comment.md', 'utf8');
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: comment
+          });
+

--- a/.github/actions/landscape-guard/check.py
+++ b/.github/actions/landscape-guard/check.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+landscape-guard checker
+
+Compares base and PR versions of landscape.yml to detect direct modifications
+to fields managed by dot-project (.project) repos. For each affected project,
+checks GitHub for a .project repo. If one exists, the change should have been
+made there instead.
+
+The dot-project is still rolling out and not yet been adapted
+by the majority of the CNCF Projects, therefore if the project
+has a .project repo, that means it should adhere to the gaurd
+and refere all meta data changes to the .project repo
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+import yaml
+
+# Fields managed by the landscape-updater (from updateItemFields in main.go)
+MANAGED_FIELDS = {"homepage_url", "description", "twitter"}
+MANAGED_EXTRA_FIELDS = {"slack_url", "linkedin_url", "youtube_url"}
+
+# Bot accounts that should bypass the check (landscape-updater automation)
+BYPASS_AUTHORS = {
+    "cncf-ci",
+    "cncf-automation",
+    "github-actions[bot]",
+    "cncf-ci[bot]",
+}
+
+
+def parse_landscape_items(path: str) -> dict:
+    """Parse landscape.yml and return a dict of item_name -> item_data.
+
+    Each item_data is a dict with the managed fields + extra fields + repo_url.
+    Key is (name, repo_url) to handle duplicate names across subcategories.
+    """
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+
+    items = {}
+    if not data or "landscape" not in data:
+        return items
+
+    for category in data["landscape"]:
+        for subcategory in category.get("subcategories", []):
+            for item in subcategory.get("items", []):
+                name = item.get("name", "")
+                repo_url = item.get("repo_url", "")
+                if not name:
+                    continue
+
+                key = (name, repo_url)
+                entry = {}
+
+                # Collect managed top-level fields
+                for field in MANAGED_FIELDS:
+                    if field in item:
+                        entry[field] = item[field]
+
+                # Collect managed extra fields
+                extra = item.get("extra", {})
+                if isinstance(extra, dict):
+                    for field in MANAGED_EXTRA_FIELDS:
+                        if field in extra:
+                            entry[f"extra.{field}"] = extra[field]
+
+                entry["_repo_url"] = repo_url
+                items[key] = entry
+
+    return items
+
+
+def find_changed_items(base_items: dict, pr_items: dict) -> list:
+    """Compare base and PR items, return list of (name, repo_url, changed_fields)."""
+    violations = []
+
+    for key, pr_entry in pr_items.items():
+        base_entry = base_items.get(key, {})
+        name, repo_url = key
+
+        changed_fields = []
+        for field in list(MANAGED_FIELDS) + [f"extra.{f}" for f in MANAGED_EXTRA_FIELDS]:
+            base_val = base_entry.get(field)
+            pr_val = pr_entry.get(field)
+            if base_val != pr_val:
+                changed_fields.append(field)
+
+        if changed_fields:
+            violations.append((name, repo_url, changed_fields))
+
+    return violations
+
+
+def extract_org_from_repo_url(repo_url: str) -> str | None:
+    """Extract GitHub org from a repo URL like https://github.com/kumahq/kuma."""
+    if not repo_url:
+        return None
+    parts = repo_url.rstrip("/").split("/")
+    # Expect: ['https:', '', 'github.com', 'org', 'repo']
+    if len(parts) >= 4 and "github.com" in parts[2]:
+        return parts[3]
+    return None
+
+
+def has_dot_project_repo(org: str, token: str) -> bool:
+    """Check if <org>/.project exists on GitHub."""
+    url = f"https://api.github.com/repos/{org}/.project"
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        urllib.request.urlopen(req)
+        return True
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return False
+        # For rate limits or other errors, assume no .project repo (fail open)
+        print(f"::warning::GitHub API returned {e.code} checking {org}/.project")
+        return False
+    except Exception as e:
+        print(f"::warning::Error checking {org}/.project: {e}")
+        return False
+
+
+def main():
+    base_path = os.environ.get("LANDSCAPE_BASE", "")
+    pr_path = os.environ.get("LANDSCAPE_PR", "")
+    token = os.environ.get("GITHUB_TOKEN", "")
+    pr_author = os.environ.get("PR_AUTHOR", "")
+    fail_on_violation = os.environ.get("FAIL_ON_VIOLATION", "false").lower() == "true"
+
+    if not base_path or not pr_path:
+        print("::error::LANDSCAPE_BASE and LANDSCAPE_PR must be set")
+        sys.exit(1)
+
+    # Bypass for automation bots
+    if pr_author in BYPASS_AUTHORS:
+        print(f"Skipping check: PR author '{pr_author}' is a known automation bot")
+        sys.exit(0)
+
+    # Parse both versions
+    base_items = parse_landscape_items(base_path)
+    pr_items = parse_landscape_items(pr_path)
+
+    # Find changes to managed fields
+    changed = find_changed_items(base_items, pr_items)
+    if not changed:
+        print("No managed field changes detected. All clear.")
+        sys.exit(0)
+
+    # For each changed item, check if a .project repo exists
+    # Cache org lookups to avoid duplicate API calls
+    org_cache: dict[str, bool] = {}
+    guarded_violations = []
+
+    for name, repo_url, changed_fields in changed:
+        org = extract_org_from_repo_url(repo_url)
+        if not org:
+            continue
+
+        if org not in org_cache:
+            org_cache[org] = has_dot_project_repo(org, token)
+
+        if org_cache[org]:
+            guarded_violations.append((name, org, changed_fields))
+
+    if not guarded_violations:
+        print("Changed items don't have .project repos. No action needed.")
+        sys.exit(0)
+
+    # Build warning message
+    lines = [
+        "## ⚠️ Landscape Guard: managed fields modified directly\n",
+        "The following project(s) have a `.project` repository that manages "
+        "these fields automatically. Please submit your changes there instead:\n",
+        "| Project | Changed Fields | Where to make changes |",
+        "|---------|---------------|----------------------|",
+    ]
+
+    for name, org, changed_fields in guarded_violations:
+        fields_str = ", ".join(f"`{f}`" for f in changed_fields)
+        repo_link = f"[`{org}/.project`](https://github.com/{org}/.project)"
+        lines.append(f"| **{name}** | {fields_str} | {repo_link} |")
+
+    lines.append("")
+    lines.append(
+        "> **Why?** These fields are synced from the project's `.project` repository. "
+        "Direct changes here will be overwritten on the next sync. "
+        "See [dot-project docs](https://github.com/cncf/automation/tree/main/utilities/dot-project) for details."
+    )
+
+    comment_body = "\n".join(lines)
+
+    # Write comment file for the action to post
+    Path("/tmp/landscape-guard-comment.md").write_text(comment_body)
+
+    # Write step summary
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write(comment_body + "\n")
+
+    # Set output so the action knows to post a comment
+    output_path = os.environ.get("GITHUB_OUTPUT", "")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as f:
+            f.write("comment=true\n")
+
+    # Print to logs
+    print(comment_body)
+
+    n = len(guarded_violations)
+    print(f"\n::warning::Found {n} project(s) with direct changes to managed fields")
+
+    if fail_on_violation:
+        print("::error::Failing check due to managed field violations (fail-on-violation=true)")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/.github/actions/landscape-guard/check.py
+++ b/.github/actions/landscape-guard/check.py
@@ -159,6 +159,8 @@ def main():
 
     # For each changed item, check if a .project repo exists
     # Cache org lookups to avoid duplicate API calls
+    # ASSUME_DOT_PROJECT=true skips the API call (useful for testing)
+    assume_dot_project = os.environ.get("ASSUME_DOT_PROJECT", "false").lower() == "true"
     org_cache: dict[str, bool] = {}
     guarded_violations = []
 
@@ -167,7 +169,9 @@ def main():
         if not org:
             continue
 
-        if org not in org_cache:
+        if assume_dot_project:
+            org_cache[org] = True
+        elif org not in org_cache:
             org_cache[org] = has_dot_project_repo(org, token)
 
         if org_cache[org]:

--- a/.github/workflows/test-landscape-guard.yml
+++ b/.github/workflows/test-landscape-guard.yml
@@ -8,22 +8,6 @@ on:
       - '.github/actions/landscape-guard/**'
 
 jobs:
-  test-unit:
-    name: Unit tests (check.py)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install pyyaml pytest
-
-      - name: Run unit tests
-        working-directory: .github/actions/landscape-guard
-        run: python -m pytest test_check.py -v
 
   test-action-warn:
     name: Action integration (warn mode)
@@ -74,6 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: "test-human"
           FAIL_ON_VIOLATION: "false"
+          ASSUME_DOT_PROJECT: "true"
           GITHUB_OUTPUT: /tmp/landscape-guard-test/github_output
           GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
         run: |
@@ -129,6 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: "test-human"
           FAIL_ON_VIOLATION: "true"
+          ASSUME_DOT_PROJECT: "true"
           GITHUB_OUTPUT: /tmp/landscape-guard-test/github_output
           GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
         run: |

--- a/.github/workflows/test-landscape-guard.yml
+++ b/.github/workflows/test-landscape-guard.yml
@@ -1,0 +1,235 @@
+# This workflow tests the landscape-guard composite action itself.
+# It runs on PRs that touch the action's code, using fixture data.
+name: Test landscape-guard action
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/landscape-guard/**'
+
+jobs:
+  test-unit:
+    name: Unit tests (check.py)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml pytest
+
+      - name: Run unit tests
+        working-directory: .github/actions/landscape-guard
+        run: python -m pytest test_check.py -v
+
+  test-action-warn:
+    name: Action integration (warn mode)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      # Create a fake base landscape.yml and a modified PR version
+      - name: Setup test fixtures
+        run: |
+          mkdir -p /tmp/landscape-guard-test
+
+          cat > /tmp/landscape-guard-test/base.yml << 'EOF'
+          landscape:
+            - name: CNCF Projects
+              subcategories:
+                - name: Orchestration
+                  items:
+                    - name: Kubernetes
+                      repo_url: https://github.com/kubernetes/kubernetes
+                      homepage_url: https://kubernetes.io
+                      description: Production-Grade Container Orchestration
+          EOF
+
+          cat > /tmp/landscape-guard-test/pr.yml << 'EOF'
+          landscape:
+            - name: CNCF Projects
+              subcategories:
+                - name: Orchestration
+                  items:
+                    - name: Kubernetes
+                      repo_url: https://github.com/kubernetes/kubernetes
+                      homepage_url: https://kubernetes-changed.io
+                      description: Production-Grade Container Orchestration
+          EOF
+
+      - name: Run checker (expect warning, exit 0)
+        env:
+          LANDSCAPE_BASE: /tmp/landscape-guard-test/base.yml
+          LANDSCAPE_PR: /tmp/landscape-guard-test/pr.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: "test-human"
+          FAIL_ON_VIOLATION: "false"
+          GITHUB_OUTPUT: /tmp/landscape-guard-test/github_output
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        run: |
+          touch /tmp/landscape-guard-test/github_output
+          python .github/actions/landscape-guard/check.py
+          echo "Check passed (warn mode) ✓"
+
+  test-action-block:
+    name: Action integration (block mode)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Setup test fixtures
+        run: |
+          mkdir -p /tmp/landscape-guard-test
+
+          cat > /tmp/landscape-guard-test/base.yml << 'EOF'
+          landscape:
+            - name: CNCF Projects
+              subcategories:
+                - name: Orchestration
+                  items:
+                    - name: Kubernetes
+                      repo_url: https://github.com/kubernetes/kubernetes
+                      homepage_url: https://kubernetes.io
+                      description: Production-Grade Container Orchestration
+          EOF
+
+          cat > /tmp/landscape-guard-test/pr.yml << 'EOF'
+          landscape:
+            - name: CNCF Projects
+              subcategories:
+                - name: Orchestration
+                  items:
+                    - name: Kubernetes
+                      repo_url: https://github.com/kubernetes/kubernetes
+                      homepage_url: https://kubernetes-changed.io
+                      description: Production-Grade Container Orchestration
+          EOF
+
+      - name: Run checker (expect exit 1 in block mode)
+        env:
+          LANDSCAPE_BASE: /tmp/landscape-guard-test/base.yml
+          LANDSCAPE_PR: /tmp/landscape-guard-test/pr.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: "test-human"
+          FAIL_ON_VIOLATION: "true"
+          GITHUB_OUTPUT: /tmp/landscape-guard-test/github_output
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        run: |
+          touch /tmp/landscape-guard-test/github_output
+          set +e
+          python .github/actions/landscape-guard/check.py
+          EXIT_CODE=$?
+          set -e
+          if [ "$EXIT_CODE" -eq 1 ]; then
+            echo "Check correctly failed in block mode ✓"
+          else
+            echo "ERROR: Expected exit code 1 but got $EXIT_CODE"
+            exit 1
+          fi
+
+  test-action-no-change:
+    name: Action integration (no changes)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Setup identical fixtures
+        run: |
+          mkdir -p /tmp/landscape-guard-test
+
+          cat > /tmp/landscape-guard-test/landscape.yml << 'EOF'
+          landscape:
+            - name: CNCF Projects
+              subcategories:
+                - name: Orchestration
+                  items:
+                    - name: Kubernetes
+                      repo_url: https://github.com/kubernetes/kubernetes
+                      homepage_url: https://kubernetes.io
+          EOF
+
+      - name: Run checker (expect clean pass)
+        env:
+          LANDSCAPE_BASE: /tmp/landscape-guard-test/landscape.yml
+          LANDSCAPE_PR: /tmp/landscape-guard-test/landscape.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: "test-human"
+          FAIL_ON_VIOLATION: "true"
+        run: |
+          python .github/actions/landscape-guard/check.py
+          echo "No changes detected ✓"
+
+  test-action-bot-bypass:
+    name: Action integration (bot bypass)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Setup test fixtures with changes
+        run: |
+          mkdir -p /tmp/landscape-guard-test
+
+          cat > /tmp/landscape-guard-test/base.yml << 'EOF'
+          landscape:
+            - name: CNCF Projects
+              subcategories:
+                - name: Orchestration
+                  items:
+                    - name: Kubernetes
+                      repo_url: https://github.com/kubernetes/kubernetes
+                      homepage_url: https://kubernetes.io
+          EOF
+
+          cat > /tmp/landscape-guard-test/pr.yml << 'EOF'
+          landscape:
+            - name: CNCF Projects
+              subcategories:
+                - name: Orchestration
+                  items:
+                    - name: Kubernetes
+                      repo_url: https://github.com/kubernetes/kubernetes
+                      homepage_url: https://kubernetes-changed.io
+          EOF
+
+      - name: Run checker as bot (expect bypass, exit 0)
+        env:
+          LANDSCAPE_BASE: /tmp/landscape-guard-test/base.yml
+          LANDSCAPE_PR: /tmp/landscape-guard-test/pr.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: "cncf-ci"
+          FAIL_ON_VIOLATION: "true"
+        run: |
+          python .github/actions/landscape-guard/check.py
+          echo "Bot bypass worked ✓"
+

--- a/.github/workflows/test-landscape-guard.yml
+++ b/.github/workflows/test-landscape-guard.yml
@@ -7,15 +7,18 @@ on:
     paths:
       - '.github/actions/landscape-guard/**'
 
+permissions:
+  contents: read
+
 jobs:
 
   test-action-warn:
     name: Action integration (warn mode)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -70,9 +73,9 @@ jobs:
     name: Action integration (block mode)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -134,9 +137,9 @@ jobs:
     name: Action integration (no changes)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -173,9 +176,9 @@ jobs:
     name: Action integration (bot bypass)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
In this PR, I introduced a landscape-guard action that checks if the landscape.yml has changed and if the dot-project managed fields have been edited.

Instead of blocking the PR on the landscape repo, it'll post a warning review comment explaining that the changes on the dot-project managed fields should be referred to the .project repo.

For each PR, we check the original project and whether the project has adopted the .project or not. If no, the check passes silently; if yes, it posts a comment.

I recommend a warning comment on the PR for the time being, since .project is still not widely adopted by the CNCF projects. Once the .project has been widely adopted, we could easily change the behavior of the actions by enabling fail-on-violation to true.