### PR TITLE
refactor: consolidate hard-coded magic values into defaults.go

### DIFF
--- a/utilities/dot-project/audit.go
+++ b/utilities/dot-project/audit.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // AuditResult represents the result of checking a project's governance/security references
@@ -28,7 +27,7 @@ type AuditCheck struct {
 // AuditProject checks that all referenced URLs in a project are accessible
 func AuditProject(project Project, client *http.Client) AuditResult {
 	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
+		client = &http.Client{Timeout: DefaultHTTPTimeout}
 	}
 
 	result := AuditResult{

--- a/utilities/dot-project/bootstrap_sources.go
+++ b/utilities/dot-project/bootstrap_sources.go
@@ -542,7 +542,7 @@ func fuzzyMatch(query string, candidates []string) (best string, score float64) 
 				if len(candidateWords) > total {
 					total = len(candidateWords)
 				}
-				s = float64(matchCount) / float64(total) * 0.5
+				s = float64(matchCount) / float64(total) * DefaultFuzzyMatchWeight
 			}
 		}
 
@@ -578,7 +578,7 @@ func detectDCOCLA(org, repo, token string, client *http.Client, baseURL string) 
 	var hasDCO, hasCLA bool
 
 	// Check recent commits for DCO (Signed-off-by)
-	resp, err := doGet(fmt.Sprintf("/repos/%s/%s/commits?per_page=20", org, repo))
+	resp, err := doGet(fmt.Sprintf("/repos/%s/%s/commits?per_page=%d", org, repo, DefaultDCOCommitSampleSize))
 	if err == nil && resp.StatusCode == http.StatusOK {
 		var commits []struct {
 			Commit struct {
@@ -592,8 +592,8 @@ func detectDCOCLA(org, repo, token string, client *http.Client, baseURL string) 
 					signedCount++
 				}
 			}
-			// If >50% of commits have Signed-off-by, likely using DCO
-			if len(commits) > 0 && float64(signedCount)/float64(len(commits)) > 0.5 {
+			// If more than DefaultDCOSignedRatio of commits have Signed-off-by, likely using DCO
+			if len(commits) > 0 && float64(signedCount)/float64(len(commits)) > DefaultDCOSignedRatio {
 				hasDCO = true
 			}
 		}

--- a/utilities/dot-project/cmd/bootstrap/main.go
+++ b/utilities/dot-project/cmd/bootstrap/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"projects"
 )
@@ -66,7 +65,7 @@ func main() {
 		token = os.Getenv("GITHUB_TOKEN")
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{Timeout: projects.DefaultHTTPTimeout}
 
 	fmt.Fprintf(os.Stderr, "Bootstrapping project: %s (slug: %s)\n", projectName, slug)
 

--- a/utilities/dot-project/cmd/staleness-checker/main.go
+++ b/utilities/dot-project/cmd/staleness-checker/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	var (
 		projectFile   = flag.String("project", "", "Path to project.yaml file (required)")
-		thresholdDays = flag.Int("threshold", 180, "Days before considering maintainers stale")
+		thresholdDays = flag.Int("threshold", projects.DefaultStalenessThresholdDays, "Days before considering maintainers stale")
 		lastUpdate    = flag.String("last-update", "", "Override last update date (YYYY-MM-DD format)")
 		outputFormat  = flag.String("output", "text", "Output format: text, json, yaml")
 	)

--- a/utilities/dot-project/defaults.go
+++ b/utilities/dot-project/defaults.go
@@ -1,0 +1,27 @@
+package projects
+
+import "time"
+
+// Centralized runtime config defaults for the dot-project tooling.
+
+const (
+	// DefaultHTTPTimeout is the timeout applied to all outbound HTTP
+	// clients (validator, bootstrap sources, etc.).
+	DefaultHTTPTimeout = 30 * time.Second
+
+	// DefaultStalenessThresholdDays is the number of days after which a
+	// project's maintainer data is considered stale.
+	DefaultStalenessThresholdDays = 180
+
+	// DefaultDCOCommitSampleSize is how many recent commits we fetch when
+	// detecting whether a repo uses DCO (Signed-off-by).
+	DefaultDCOCommitSampleSize = 20
+
+	// DefaultDCOSignedRatio is the minimum ratio of Signed-off-by commits
+	// to total sampled commits before we consider DCO "enabled".
+	DefaultDCOSignedRatio = 0.5
+
+	// DefaultFuzzyMatchWeight is the weight applied to partial word-match
+	// scores when fuzzy-matching project names against landscape entries.
+	DefaultFuzzyMatchWeight = 0.5
+)

--- a/utilities/dot-project/validator.go
+++ b/utilities/dot-project/validator.go
@@ -38,7 +38,7 @@ func NewProjectValidator(configPath string) (*ProjectValidator, error) {
 	return &ProjectValidator{
 		config: config,
 		cache:  cache,
-		client: &http.Client{Timeout: 30 * time.Second},
+		client: &http.Client{Timeout: DefaultHTTPTimeout},
 	}, nil
 }
 
@@ -649,7 +649,7 @@ func NewValidator(cacheDir string) *ProjectValidator {
 	return &ProjectValidator{
 		config: config,
 		cache:  cache,
-		client: &http.Client{Timeout: 30 * time.Second},
+		client: &http.Client{Timeout: DefaultHTTPTimeout},
 	}
 }
 


### PR DESCRIPTION
All the scattered values have been centralized in `defaults.go`, although some of the values are only used once in the codebase, it is still a good idea to centralize them for future reference.

- `DefaultFuzzyMatchWeight`: 0.5
- `DefaultDCOSignedRatio`: 0.5
- `DefaultDCOCommitSampleSize`: 20 days
- `DefaultStalenessThresholdDays`: 180 days
- `DefaultHTTPTimeout`: 30 seconds