### PR TITLE
CLOMonitor search API Fix

### DIFF
--- a/utilities/dot-project/bootstrap_sources.go
+++ b/utilities/dot-project/bootstrap_sources.go
@@ -20,8 +20,9 @@ const (
 	landscapeLogoBaseURL    = "https://landscape.cncf.io/logos/"
 )
 
-// fetchFromCLOMonitor queries the CLOMonitor API for a CNCF project by display name.
-// It fuzzy-matches the display_name, filtering for foundation=cncf.
+// fetchFromCLOMonitor queries the CLOMonitor search API for a CNCF project by display name.
+// It passes text and foundation=cncf as query parameters so the server filters results,
+// then fuzzy-matches the display_name among the returned candidates.
 // baseURL overrides the CLOMonitor API base (use "" for default).
 // Returns nil if no match is found.
 func fetchFromCLOMonitor(name string, client *http.Client, baseURL string) (*CLOMonitorProject, error) {
@@ -29,8 +30,12 @@ func fetchFromCLOMonitor(name string, client *http.Client, baseURL string) (*CLO
 		baseURL = defaultCLOMonitorURL
 	}
 
-	url := baseURL + cloMonitorSearchPath
-	resp, err := client.Get(url)
+	params := url.Values{}
+	params.Set("text", name)
+	params.Set("foundation", "cncf")
+	fullURL := baseURL + cloMonitorSearchPath + "?" + params.Encode()
+
+	resp, err := client.Get(fullURL)
 	if err != nil {
 		return nil, fmt.Errorf("CLOMonitor request failed: %w", err)
 	}
@@ -50,21 +55,13 @@ func fetchFromCLOMonitor(name string, client *http.Client, baseURL string) (*CLO
 		return nil, fmt.Errorf("parsing CLOMonitor response: %w", err)
 	}
 
-	// Filter to CNCF foundation only
-	var cncfProjects []CLOMonitorProject
-	for _, p := range results {
-		if strings.EqualFold(p.Foundation, "cncf") {
-			cncfProjects = append(cncfProjects, p)
-		}
-	}
-
-	if len(cncfProjects) == 0 {
+	if len(results) == 0 {
 		return nil, nil
 	}
 
-	// Fuzzy match by display name
+	// Fuzzy match by display name among the server-filtered results
 	var candidates []string
-	for _, p := range cncfProjects {
+	for _, p := range results {
 		candidates = append(candidates, p.DisplayName)
 	}
 
@@ -73,9 +70,9 @@ func fetchFromCLOMonitor(name string, client *http.Client, baseURL string) (*CLO
 		return nil, nil
 	}
 
-	for i, p := range cncfProjects {
+	for i, p := range results {
 		if p.DisplayName == best {
-			return &cncfProjects[i], nil
+			return &results[i], nil
 		}
 	}
 

--- a/utilities/dot-project/bootstrap_sources_test.go
+++ b/utilities/dot-project/bootstrap_sources_test.go
@@ -9,9 +9,21 @@ import (
 )
 
 func TestFetchFromCLOMonitor(t *testing.T) {
+	// helper checks that the request carries the expected search query params
+	checkSearchParams := func(t *testing.T, r *http.Request, wantText string) {
+		t.Helper()
+		if got := r.URL.Query().Get("text"); got != wantText {
+			t.Errorf("query param text = %q, want %q", got, wantText)
+		}
+		if got := r.URL.Query().Get("foundation"); got != "cncf" {
+			t.Errorf("query param foundation = %q, want %q", got, "cncf")
+		}
+	}
+
 	t.Run("finds project by display name", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/api/projects/search" {
+				checkSearchParams(t, r, "Kubernetes")
 				results := []CLOMonitorProject{
 					{
 						Name:        "kubernetes",
@@ -63,6 +75,8 @@ func TestFetchFromCLOMonitor(t *testing.T) {
 
 	t.Run("case insensitive fuzzy match", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			checkSearchParams(t, r, "argo cd")
+			// Server returns candidates matching the query (as the real API would)
 			results := []CLOMonitorProject{
 				{Name: "argo", DisplayName: "Argo", Foundation: "cncf"},
 				{Name: "argo-cd", DisplayName: "Argo CD", Foundation: "cncf"},
@@ -86,6 +100,7 @@ func TestFetchFromCLOMonitor(t *testing.T) {
 
 	t.Run("no match returns nil", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			checkSearchParams(t, r, "nonexistent")
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode([]CLOMonitorProject{})
 		}))
@@ -100,10 +115,15 @@ func TestFetchFromCLOMonitor(t *testing.T) {
 		}
 	})
 
-	t.Run("filters by CNCF foundation", func(t *testing.T) {
+	t.Run("sends foundation=cncf query param", func(t *testing.T) {
+		// Server-side filtering is now delegated to the API via foundation=cncf.
+		// Verify the param is sent and that the client picks the best fuzzy match
+		// from whatever the server returns.
+		var gotFoundation string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotFoundation = r.URL.Query().Get("foundation")
+			// Simulate server returning only CNCF results (as the real API does)
 			results := []CLOMonitorProject{
-				{Name: "test", DisplayName: "Test", Foundation: "lfai"},
 				{Name: "test-cncf", DisplayName: "Test CNCF", Foundation: "cncf"},
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -115,8 +135,11 @@ func TestFetchFromCLOMonitor(t *testing.T) {
 		if err != nil {
 			t.Fatalf("fetchFromCLOMonitor() error = %v", err)
 		}
+		if gotFoundation != "cncf" {
+			t.Errorf("foundation query param = %q, want %q", gotFoundation, "cncf")
+		}
 		if result == nil {
-			t.Fatal("expected a CNCF match")
+			t.Fatal("expected a match")
 		}
 		if result.Foundation != "cncf" {
 			t.Errorf("Foundation = %q, want %q", result.Foundation, "cncf")


### PR DESCRIPTION
Pass `text=project-name` and `foundation=cncf` as query params so the server filters results to CNCF projects matching the name, then fuzzy-match the returned candidates to pick the best one.