### PR TITLE
feat: collect all Slack channels across org repos

### DIFF
--- a/utilities/dot-project/bootstrap_parsers.go
+++ b/utilities/dot-project/bootstrap_parsers.go
@@ -107,38 +107,80 @@ var handlePattern = regexp.MustCompile(`@([a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9
 // githubURLPattern matches https://github.com/<username> in text.
 var githubURLPattern = regexp.MustCompile(`https?://github\.com/([a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?)(?:\s|$|\)|,)`)
 
-// slackChannelURLPattern matches cloud-native.slack.com/messages/<channel> URLs.
-var slackChannelURLPattern = regexp.MustCompile(`cloud-native\.slack\.com/(?:messages|archives)/#?([a-zA-Z0-9][a-zA-Z0-9_-]*)`)
+// slackChannelURLPattern matches cloud-native.slack.com/{messages,archives,channels}/<channel> URLs.
+var slackChannelURLPattern = regexp.MustCompile(`cloud-native\.slack\.com/(?:messages|archives|channels)/#?([a-zA-Z0-9][a-zA-Z0-9_-]*)`)
 
 // slackContextPattern matches "#channel-name" near Slack-related keywords.
 // Looks for lines containing "slack" (case-insensitive) with a #channel reference.
 var slackContextPattern = regexp.MustCompile(`(?i)(?:slack|cncf).*?(#[a-z][a-z0-9_-]+)`)
 
-// extractSlackChannel extracts a CNCF Slack channel name from README content.
-// It looks for cloud-native.slack.com/messages/<channel> URLs first, then
-// falls back to #channel-name references near Slack keywords.
+// slackChannelLinePattern matches a line like "Channel: #channel-name" or "- #channel-name" standalone.
+var slackChannelLinePattern = regexp.MustCompile(`(?i)channel\s*[:\-]\s*(#[a-z][a-z0-9_-]+)`)
+
+// extractSlackChannel extracts the first CNCF Slack channel name from content.
+// Convenience wrapper around extractSlackChannels.
 // Returns a channel name with "#" prefix (e.g., "#tokenetes") or "" if not found.
 func extractSlackChannel(content string) string {
-	if content == "" {
-		return ""
+	channels := extractSlackChannels(content)
+	if len(channels) > 0 {
+		return channels[0]
 	}
-
-	// Priority 1: cloud-native.slack.com/messages/<channel> URL
-	if matches := slackChannelURLPattern.FindStringSubmatch(content); len(matches) > 1 {
-		channel := strings.TrimRight(matches[1], "/)")
-		if channel != "" {
-			return "#" + channel
-		}
-	}
-
-	// Priority 2: #channel-name near Slack keywords
-	for _, line := range strings.Split(content, "\n") {
-		if matches := slackContextPattern.FindStringSubmatch(line); len(matches) > 1 {
-			return matches[1] // already has "#" prefix
-		}
-	}
-
 	return ""
+}
+
+// extractSlackChannels extracts all unique CNCF Slack channel names from content.
+// It looks for cloud-native.slack.com/{messages,archives,channels}/<channel> URLs,
+// then #channel-name references near Slack keywords,
+// then standalone "Channel: #name" patterns near Slack context.
+// Returns deduplicated channel names with "#" prefix, in discovery order.
+func extractSlackChannels(content string) []string {
+	if content == "" {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var channels []string
+
+	addChannel := func(ch string) {
+		if ch != "" && !seen[ch] {
+			seen[ch] = true
+			channels = append(channels, ch)
+		}
+	}
+
+	// Priority 1: cloud-native.slack.com/{messages,archives,channels}/<channel> URL
+	if matches := slackChannelURLPattern.FindAllStringSubmatch(content, -1); len(matches) > 0 {
+		for _, m := range matches {
+			channel := strings.TrimRight(m[1], "/)")
+			if channel != "" {
+				addChannel("#" + channel)
+			}
+		}
+	}
+
+	// Priority 2: #channel-name on the same line as Slack/CNCF keywords
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		if matches := slackContextPattern.FindStringSubmatch(line); len(matches) > 1 {
+			addChannel(matches[1]) // already has "#" prefix
+		}
+	}
+
+	// Priority 3: "Channel: #name" pattern on a line near a Slack mention (within 3 lines)
+	for i, line := range lines {
+		if matches := slackChannelLinePattern.FindStringSubmatch(line); len(matches) > 1 {
+			start := i - 3
+			if start < 0 {
+				start = 0
+			}
+			context := strings.ToLower(strings.Join(lines[start:i+1], " "))
+			if strings.Contains(context, "slack") {
+				addChannel(matches[1])
+			}
+		}
+	}
+
+	return channels
 }
 
 // parseMaintainersFile heuristically extracts GitHub handles from a MAINTAINERS file.

--- a/utilities/dot-project/bootstrap_parsers.go
+++ b/utilities/dot-project/bootstrap_parsers.go
@@ -117,6 +117,10 @@ var slackContextPattern = regexp.MustCompile(`(?i)(?:slack|cncf).*?(#[a-z][a-z0-
 // slackChannelLinePattern matches a line like "Channel: #channel-name" or "- #channel-name" standalone.
 var slackChannelLinePattern = regexp.MustCompile(`(?i)channel\s*[:\-]\s*(#[a-z][a-z0-9_-]+)`)
 
+// slackChannelIDPattern matches internal Slack channel IDs like "C01N7PP1THC" or "D03FAB6GN0K".
+// These appear in /archives/ URLs and are not human-readable channel names.
+var slackChannelIDPattern = regexp.MustCompile(`^#?[A-Z][A-Z0-9]{8,}$`)
+
 // extractSlackChannel extracts the first CNCF Slack channel name from content.
 // Convenience wrapper around extractSlackChannels.
 // Returns a channel name with "#" prefix (e.g., "#tokenetes") or "" if not found.
@@ -142,10 +146,21 @@ func extractSlackChannels(content string) []string {
 	var channels []string
 
 	addChannel := func(ch string) {
-		if ch != "" && !seen[ch] {
-			seen[ch] = true
-			channels = append(channels, ch)
+		if ch == "" || seen[ch] {
+			return
 		}
+		// Skip internal Slack channel IDs (e.g., #C01N7PP1THC, #D03FAB6GN0K)
+		if slackChannelIDPattern.MatchString(ch) {
+			return
+		}
+		// Skip generic words that aren't real channel names
+		lower := strings.ToLower(ch)
+		switch lower {
+		case "#slack", "#cncf", "#channel", "#channels":
+			return
+		}
+		seen[ch] = true
+		channels = append(channels, ch)
 	}
 
 	// Priority 1: cloud-native.slack.com/{messages,archives,channels}/<channel> URL

--- a/utilities/dot-project/bootstrap_parsers_test.go
+++ b/utilities/dot-project/bootstrap_parsers_test.go
@@ -432,6 +432,18 @@ For mobile: Slack channel #envoy-mobile`,
 CNCF Slack: #project-dev`,
 			expected: []string{"#project-general", "#project-dev"},
 		},
+		{
+			name: "filters out Slack channel IDs from archives URLs",
+			content: `Join us on [Slack](https://cloud-native.slack.com/archives/C01N7PP1THC)
+or [#opentelemetry](https://cloud-native.slack.com/messages/opentelemetry)
+See also https://cloud-native.slack.com/archives/D03FAB6GN0K`,
+			expected: []string{"#opentelemetry"},
+		},
+		{
+			name:     "filters out generic #slack keyword",
+			content:  "Join our Slack community at #slack for discussions",
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/utilities/dot-project/bootstrap_parsers_test.go
+++ b/utilities/dot-project/bootstrap_parsers_test.go
@@ -303,3 +303,149 @@ Alice Smith (@alice) - Also lead`,
 		})
 	}
 }
+
+func TestExtractSlackChannel(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "empty content",
+			content:  "",
+			expected: "",
+		},
+		{
+			name:     "messages URL",
+			content:  "Join us at https://cloud-native.slack.com/messages/my-project",
+			expected: "#my-project",
+		},
+		{
+			name:     "archives URL",
+			content:  "Join us at https://cloud-native.slack.com/archives/my-project",
+			expected: "#my-project",
+		},
+		{
+			name:     "channels URL",
+			content:  "Join us at https://cloud-native.slack.com/channels/my-project",
+			expected: "#my-project",
+		},
+		{
+			name:     "channels URL in markdown link",
+			content:  "[#my-project](https://cloud-native.slack.com/channels/my-project)",
+			expected: "#my-project",
+		},
+		{
+			name:     "channels URL with trailing slash",
+			content:  "https://cloud-native.slack.com/channels/my-project/",
+			expected: "#my-project",
+		},
+		{
+			name:     "hash channel on same line as Slack keyword",
+			content:  "Slack: #my-project",
+			expected: "#my-project",
+		},
+		{
+			name:     "hash channel on same line as CNCF keyword",
+			content:  "CNCF Slack channel: #my-project",
+			expected: "#my-project",
+		},
+		{
+			name: "channel on separate line near Slack mention",
+			content: `## Community
+Join our Slack workspace
+Channel: #my-project`,
+			expected: "#my-project",
+		},
+		{
+			name: "channel on line 3 lines after Slack mention",
+			content: `Join us on Slack:
+Some info
+More info
+Channel: #my-project`,
+			expected: "#my-project",
+		},
+		{
+			name:     "no slack reference at all",
+			content:  "This project is great!",
+			expected: "",
+		},
+		{
+			name: "channel too far from Slack mention",
+			content: `Join us on Slack
+line1
+line2
+line3
+line4
+Channel: #my-project`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSlackChannel(tt.content)
+			if got != tt.expected {
+				t.Errorf("extractSlackChannel() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractSlackChannels(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "empty content",
+			content:  "",
+			expected: nil,
+		},
+		{
+			name:     "single channel from URL",
+			content:  "Join us at https://cloud-native.slack.com/messages/my-project",
+			expected: []string{"#my-project"},
+		},
+		{
+			name: "multiple channels from URLs",
+			content: `Join [#envoy](https://cloud-native.slack.com/channels/envoy) or
+[#envoy-dev](https://cloud-native.slack.com/channels/envoy-dev) for development discussions.`,
+			expected: []string{"#envoy", "#envoy-dev"},
+		},
+		{
+			name: "deduplicates same channel from URL and context",
+			content: `Slack: #my-project
+More info at https://cloud-native.slack.com/messages/my-project`,
+			expected: []string{"#my-project"},
+		},
+		{
+			name: "mixed URL and keyword sources",
+			content: `Join [#envoy](https://cloud-native.slack.com/channels/envoy)
+For mobile: Slack channel #envoy-mobile`,
+			expected: []string{"#envoy", "#envoy-mobile"},
+		},
+		{
+			name: "multiple keyword-based channels",
+			content: `Slack: #project-general
+CNCF Slack: #project-dev`,
+			expected: []string{"#project-general", "#project-dev"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSlackChannels(tt.content)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("extractSlackChannels() returned %d channels, want %d\ngot:  %v\nwant: %v",
+					len(got), len(tt.expected), got, tt.expected)
+			}
+			for i, ch := range got {
+				if ch != tt.expected[i] {
+					t.Errorf("extractSlackChannels()[%d] = %q, want %q", i, ch, tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/utilities/dot-project/bootstrap_scaffold.go
+++ b/utilities/dot-project/bootstrap_scaffold.go
@@ -25,7 +25,8 @@ description: "{{ .Description }}"
 type: "project"
 {{ if .ProjectLead }}project_lead: "{{ .ProjectLead }}"{{ if isAutoDetected .Sources "project_lead" }} # TODO: AUTO-DETECTED — please verify{{ end }}{{ else }}# TODO: Set project lead GitHub handle
 # project_lead: "github-handle"{{ end }}
-{{ if .CNCFSlackChannel }}cncf_slack_channel: "{{ .CNCFSlackChannel }}"{{ if isAutoDetected .Sources "cncf_slack_channel" }} # TODO: AUTO-DETECTED — please verify{{ end }}{{ else }}# TODO: Set CNCF Slack channel
+{{ if .CNCFSlackChannel }}cncf_slack_channel: "{{ .CNCFSlackChannel }}"{{ if isAutoDetected .Sources "cncf_slack_channel" }} # TODO: AUTO-DETECTED — please verify{{ end }}{{ if .CNCFSlackCandidates }}
+# Also detected: {{ joinChannels .CNCFSlackCandidates }} — please verify the correct channel{{ end }}{{ else }}# TODO: Set CNCF Slack channel
 # cncf_slack_channel: "#{{ .Slug }}"{{ end }}
 
 maturity_log:
@@ -261,6 +262,13 @@ var templateFuncs = template.FuncMap{
 		}
 		_, ok := sources[key]
 		return ok
+	},
+	"joinChannels": func(channels []string) string {
+		quoted := make([]string, len(channels))
+		for i, ch := range channels {
+			quoted[i] = `"` + ch + `"`
+		}
+		return strings.Join(quoted, ", ")
 	},
 }
 

--- a/utilities/dot-project/bootstrap_scaffold_test.go
+++ b/utilities/dot-project/bootstrap_scaffold_test.go
@@ -429,6 +429,60 @@ func TestGenerateProjectYAML_AutoDetected(t *testing.T) {
 		}
 	})
 
+	t.Run("renders slack candidates as comments", func(t *testing.T) {
+		result := &BootstrapResult{
+			Slug:                "envoy",
+			Name:                "Envoy",
+			Description:         "A test",
+			GitHubOrg:           "envoyproxy",
+			GitHubRepo:          "envoy",
+			CNCFSlackChannel:    "#envoy",
+			CNCFSlackCandidates: []string{"#envoy-dev", "#envoy-mobile"},
+			Sources:             map[string]string{"cncf_slack_channel": "github_readme"},
+		}
+
+		output, err := GenerateProjectYAML(result)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		yamlStr := string(output)
+
+		if !strings.Contains(yamlStr, `cncf_slack_channel: "#envoy"`) {
+			t.Error("should contain primary cncf_slack_channel value")
+		}
+		if !strings.Contains(yamlStr, `Also detected: "#envoy-dev", "#envoy-mobile"`) {
+			t.Errorf("should contain candidates comment, got:\n%s", yamlStr)
+		}
+		if !strings.Contains(yamlStr, "please verify the correct channel") {
+			t.Error("should contain verification prompt for candidates")
+		}
+	})
+
+	t.Run("no candidates comment when only one channel", func(t *testing.T) {
+		result := &BootstrapResult{
+			Slug:             "test-project",
+			Name:             "Test Project",
+			Description:      "A test",
+			GitHubOrg:        "test-org",
+			GitHubRepo:       "test-project",
+			CNCFSlackChannel: "#test-project",
+			Sources:          map[string]string{"cncf_slack_channel": "github_readme"},
+		}
+
+		output, err := GenerateProjectYAML(result)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		yamlStr := string(output)
+
+		if !strings.Contains(yamlStr, `cncf_slack_channel: "#test-project"`) {
+			t.Error("should contain cncf_slack_channel value")
+		}
+		if strings.Contains(yamlStr, "Also detected") {
+			t.Error("should NOT contain candidates comment when no candidates")
+		}
+	})
+
 	t.Run("uses auto-detected TOC issue URL", func(t *testing.T) {
 		result := &BootstrapResult{
 			Slug:          "test-project",

--- a/utilities/dot-project/bootstrap_sources.go
+++ b/utilities/dot-project/bootstrap_sources.go
@@ -233,8 +233,8 @@ type GitHubData struct {
 	HasDCO bool `json:"has_dco,omitempty"`
 	HasCLA bool `json:"has_cla,omitempty"`
 
-	// Slack channel - for auto detection
-	SlackChannel string `json:"slack_channel,omitempty"`
+	// Slack channels discovered across the org
+	SlackChannels []string `json:"slack_channels,omitempty"`
 }
 
 // fetchFromGitHub fetches repository, organization, community profile, and
@@ -320,7 +320,7 @@ func fetchFromGitHub(org, repo, token string, client *http.Client, baseURL strin
 	result.HasDCO = hasDCO
 	result.HasCLA = hasCLA
 
-	// Fetch README and extract Slack channel
+	// Fetch README and extract Slack channels
 	if resp, err := doGet(fmt.Sprintf("/repos/%s/%s/readme", org, repo)); err == nil {
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
@@ -329,9 +329,8 @@ func fetchFromGitHub(org, repo, token string, client *http.Client, baseURL strin
 			}
 			if err := json.NewDecoder(resp.Body).Decode(&readmeData); err == nil && readmeData.DownloadURL != "" {
 				if content, err := fetchFileContent(client, readmeData.DownloadURL); err == nil {
-					if ch := extractSlackChannel(content); ch != "" {
-						result.SlackChannel = ch
-					}
+					channels := extractSlackChannels(content)
+					result.SlackChannels = mergeStringSlices(result.SlackChannels, channels)
 				}
 			}
 		}
@@ -390,6 +389,20 @@ var governanceFiles = []governanceFile{
 			}
 		},
 	},
+	{
+		name: "CONTRIBUTING.md",
+		parseFunc: func(data *GitHubData, content string, _ string) {
+			channels := extractSlackChannels(content)
+			data.SlackChannels = mergeStringSlices(data.SlackChannels, channels)
+		},
+	},
+	{
+		name: "COMMUNITY.md",
+		parseFunc: func(data *GitHubData, content string, _ string) {
+			channels := extractSlackChannels(content)
+			data.SlackChannels = mergeStringSlices(data.SlackChannels, channels)
+		},
+	},
 }
 
 // discoverGovernanceFiles looks for CODEOWNERS, OWNERS, MAINTAINERS in the repo root,
@@ -445,7 +458,7 @@ func scanOrgReposForGovernance(result *GitHubData, org, primaryRepo string, doGe
 		".github":                    true,
 	}
 
-	fmt.Fprintf(os.Stderr, "  Scanning all repos in %s org for maintainer handles...\n", org)
+	fmt.Fprintf(os.Stderr, "  Scanning all repos in %s org for maintainer handles and Slack channels...\n", org)
 	before := len(result.Maintainers)
 
 	page := 1
@@ -496,7 +509,8 @@ func scanOrgReposForGovernance(result *GitHubData, org, primaryRepo string, doGe
 }
 
 // scanRepoRootForGovernance lists the root contents of a single repo and parses
-// any governance files found there.
+// any governance files found there. It also extracts Slack channels from the
+// repo README to discover channels across the entire org.
 func scanRepoRootForGovernance(result *GitHubData, org, repo string, doGet func(string) (*http.Response, error), client *http.Client) {
 	resp, err := doGet(fmt.Sprintf("/repos/%s/%s/contents/", org, repo))
 	if err != nil || resp.StatusCode != http.StatusOK {
@@ -520,6 +534,15 @@ func scanRepoRootForGovernance(result *GitHubData, org, repo string, doGet func(
 				if err == nil && content != "" {
 					gf.parseFunc(result, content, entry.HTMLURL)
 				}
+			}
+		}
+		// Also check README for Slack channels
+		if entry.Type == "file" && entry.DownloadURL != "" &&
+			strings.EqualFold(strings.TrimSuffix(entry.Name, ".md"), "README") {
+			content, err := fetchFileContent(client, entry.DownloadURL)
+			if err == nil && content != "" {
+				channels := extractSlackChannels(content)
+				result.SlackChannels = mergeStringSlices(result.SlackChannels, channels)
 			}
 		}
 	}
@@ -575,6 +598,26 @@ func getExtraString(extra map[string]interface{}, key string) (string, bool) {
 	}
 	s, ok := v.(string)
 	return s, ok
+}
+
+// extractChannelFromSlackURL extracts a channel name from a Slack URL.
+// Handles URLs like:
+//   - https://cloud-native.slack.com/messages/my-project
+//   - https://cloud-native.slack.com/channels/my-project
+//   - https://cloud-native.slack.com/archives/my-project
+//
+// Returns the channel name without "#" prefix, or "" if not found.
+func extractChannelFromSlackURL(slackURL string) string {
+	for _, segment := range []string{"/messages/", "/channels/", "/archives/"} {
+		parts := strings.SplitN(slackURL, segment, 2)
+		if len(parts) == 2 && parts[1] != "" {
+			channel := strings.TrimRight(parts[1], "/")
+			if channel != "" {
+				return channel
+			}
+		}
+	}
+	return ""
 }
 
 // LandscapeData represents data fetched from the CNCF landscape.
@@ -910,20 +953,39 @@ func mergeBootstrapData(slug string, landscape *LandscapeData, clomonitor *CLOMo
 		result.Sources["social.twitter"] = "github"
 	}
 
-	// Slack channel: landscape extra.chat_channel > derived from extra.slack_url > GitHub README
+	// Slack channel: landscape extra.chat_channel > derived from extra.slack_url > GitHub org-wide scan
+	// Landscape values are authoritative; GitHub-discovered channels become candidates.
 	if landscape != nil && landscape.ChatChannel != "" {
 		result.CNCFSlackChannel = landscape.ChatChannel
 		result.Sources["cncf_slack_channel"] = "landscape"
 	} else if landscape != nil && landscape.SlackURL != "" {
-		// Derive channel name from slack URL: .../messages/<channel-name>
-		parts := strings.Split(landscape.SlackURL, "/messages/")
-		if len(parts) == 2 && parts[1] != "" {
-			result.CNCFSlackChannel = "#" + parts[1]
+		// Derive channel name from slack URL: .../messages/<channel-name> or .../channels/<channel-name> or .../archives/<channel-name>
+		channel := extractChannelFromSlackURL(landscape.SlackURL)
+		if channel != "" {
+			result.CNCFSlackChannel = "#" + channel
 			result.Sources["cncf_slack_channel"] = "landscape"
 		}
-	} else if github != nil && github.SlackChannel != "" {
-		result.CNCFSlackChannel = github.SlackChannel
-		result.Sources["cncf_slack_channel"] = "github_readme"
+	}
+
+	// Collect all GitHub-discovered Slack channels
+	if github != nil && len(github.SlackChannels) > 0 {
+		if result.CNCFSlackChannel == "" {
+			// No landscape value — promote the first GitHub channel as primary
+			result.CNCFSlackChannel = github.SlackChannels[0]
+			result.Sources["cncf_slack_channel"] = "github_readme"
+			// Remaining channels become candidates
+			if len(github.SlackChannels) > 1 {
+				result.CNCFSlackCandidates = append([]string{}, github.SlackChannels[1:]...)
+			}
+		} else {
+			// Landscape provided a primary — all GitHub channels are candidates
+			// (excluding duplicates of the landscape value)
+			for _, ch := range github.SlackChannels {
+				if ch != result.CNCFSlackChannel {
+					result.CNCFSlackCandidates = append(result.CNCFSlackCandidates, ch)
+				}
+			}
+		}
 	}
 
 	// Accepted date from landscape extra

--- a/utilities/dot-project/bootstrap_sources_test.go
+++ b/utilities/dot-project/bootstrap_sources_test.go
@@ -935,6 +935,81 @@ func TestMergeBootstrapData_ExtraFields(t *testing.T) {
 		}
 	})
 
+	t.Run("derives slack channel from channels URL in slack_url", func(t *testing.T) {
+		landscape := &LandscapeData{
+			Name:     "Test Project",
+			Maturity: "sandbox",
+			SlackURL: "https://cloud-native.slack.com/channels/test-project",
+		}
+		result := mergeBootstrapData("test-project", landscape, nil, nil)
+		if result.CNCFSlackChannel != "#test-project" {
+			t.Errorf("CNCFSlackChannel = %q, want #test-project", result.CNCFSlackChannel)
+		}
+	})
+
+	t.Run("derives slack channel from archives URL in slack_url", func(t *testing.T) {
+		landscape := &LandscapeData{
+			Name:     "Test Project",
+			Maturity: "sandbox",
+			SlackURL: "https://cloud-native.slack.com/archives/test-project",
+		}
+		result := mergeBootstrapData("test-project", landscape, nil, nil)
+		if result.CNCFSlackChannel != "#test-project" {
+			t.Errorf("CNCFSlackChannel = %q, want #test-project", result.CNCFSlackChannel)
+		}
+	})
+
+	t.Run("promotes first GitHub channel as primary when no landscape", func(t *testing.T) {
+		github := &GitHubData{
+			SlackChannels: []string{"#envoy", "#envoy-dev", "#envoy-mobile"},
+		}
+		result := mergeBootstrapData("envoy", nil, nil, github)
+		if result.CNCFSlackChannel != "#envoy" {
+			t.Errorf("CNCFSlackChannel = %q, want #envoy", result.CNCFSlackChannel)
+		}
+		if len(result.CNCFSlackCandidates) != 2 {
+			t.Fatalf("CNCFSlackCandidates len = %d, want 2", len(result.CNCFSlackCandidates))
+		}
+		if result.CNCFSlackCandidates[0] != "#envoy-dev" || result.CNCFSlackCandidates[1] != "#envoy-mobile" {
+			t.Errorf("CNCFSlackCandidates = %v, want [#envoy-dev, #envoy-mobile]", result.CNCFSlackCandidates)
+		}
+	})
+
+	t.Run("landscape primary with GitHub candidates", func(t *testing.T) {
+		landscape := &LandscapeData{
+			Name:        "Envoy",
+			Maturity:    "graduated",
+			ChatChannel: "#envoy",
+		}
+		github := &GitHubData{
+			SlackChannels: []string{"#envoy", "#envoy-dev", "#envoy-mobile"},
+		}
+		result := mergeBootstrapData("envoy", landscape, nil, github)
+		if result.CNCFSlackChannel != "#envoy" {
+			t.Errorf("CNCFSlackChannel = %q, want #envoy", result.CNCFSlackChannel)
+		}
+		// #envoy is already primary, so candidates should be the other two
+		if len(result.CNCFSlackCandidates) != 2 {
+			t.Fatalf("CNCFSlackCandidates len = %d, want 2", len(result.CNCFSlackCandidates))
+		}
+		if result.CNCFSlackCandidates[0] != "#envoy-dev" || result.CNCFSlackCandidates[1] != "#envoy-mobile" {
+			t.Errorf("CNCFSlackCandidates = %v, want [#envoy-dev, #envoy-mobile]", result.CNCFSlackCandidates)
+		}
+	})
+
+	t.Run("single GitHub channel has no candidates", func(t *testing.T) {
+		github := &GitHubData{
+			SlackChannels: []string{"#my-project"},
+		}
+		result := mergeBootstrapData("my-project", nil, nil, github)
+		if result.CNCFSlackChannel != "#my-project" {
+			t.Errorf("CNCFSlackChannel = %q, want #my-project", result.CNCFSlackChannel)
+		}
+		if len(result.CNCFSlackCandidates) != 0 {
+			t.Errorf("CNCFSlackCandidates = %v, want empty", result.CNCFSlackCandidates)
+		}
+	})
+
 	t.Run("sets accepted date from landscape extra", func(t *testing.T) {
 		landscape := &LandscapeData{
 			Name:         "Test Project",

--- a/utilities/dot-project/bootstrap_types.go
+++ b/utilities/dot-project/bootstrap_types.go
@@ -41,6 +41,9 @@ type BootstrapResult struct {
 	ProjectLead      string `json:"project_lead,omitempty" yaml:"project_lead,omitempty"`
 	CNCFSlackChannel string `json:"cncf_slack_channel,omitempty" yaml:"cncf_slack_channel,omitempty"`
 
+	// Additional Slack channels detected across the org
+	CNCFSlackCandidates []string `json:"cncf_slack_candidates,omitempty" yaml:"cncf_slack_candidates,omitempty"`
+
 	// Maintainers discovered from CODEOWNERS/OWNERS/MAINTAINERS files
 	Maintainers []string `json:"maintainers,omitempty" yaml:"maintainers,omitempty"`
 	Reviewers   []string `json:"reviewers,omitempty" yaml:"reviewers,omitempty"`


### PR DESCRIPTION
I extended the discovery for Slack Channels to the other governance files (CONTRIBUTING.md, COMMUNITY.md) and not only in the primary repo, but also in the entire org's repos. 

This doesn't cause more GH API calls, I'm utilizing the maintainers' list lookup API Call.

If more than one slack reference was found, we list them as comments in the `project.yml` for Org owners' verification