### PR TITLE
fix: prevent landscape updater from opening PRs with insignificant changes

### DIFF
--- a/utilities/dot-project/cmd/landscape-updater/main.go
+++ b/utilities/dot-project/cmd/landscape-updater/main.go
@@ -15,6 +15,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// fieldEdit describes a single field change to apply to the landscape file.
+type fieldEdit struct {
+	key      string
+	newValue string
+	isExtra  bool // true if this field belongs under the extra: mapping
+	exists   bool // true = update existing field, false = insert new field
+}
+
 func main() {
 	projectPath := flag.String("project", "", "Path to project.yaml")
 	landscapePath := flag.String("landscape", "", "Path to landscape.yml")
@@ -47,36 +55,41 @@ func main() {
 		log.Fatalf("Failed to parse landscape YAML: %v", err)
 	}
 
-	// Update
-	updated := updateLandscape(&root, &project)
+	lines := strings.Split(string(landscapeData), "\n")
+
+	// Update using line-level edits
+	newLines, updated := updateLandscape(&root, &project, lines)
 	if !updated {
-		log.Printf("No matching entry found for project %s", project.Name)
+		log.Printf("No matching entry found or no changes needed for project %s", project.Name)
 		os.Exit(0)
 	}
 
+	output := strings.Join(newLines, "\n")
+
 	if *dryRun {
-		// Create temp file for new content
 		tmpFile, err := os.CreateTemp("", "landscape-*.yml")
 		if err != nil {
 			log.Fatalf("Failed to create temp file: %v", err)
 		}
-		defer os.Remove(tmpFile.Name())
+		defer func() {
+			if err := os.Remove(tmpFile.Name()); err != nil {
+				log.Printf("Warning: failed to remove temp file: %v", err)
+			}
+		}()
 
-		encoder := yaml.NewEncoder(tmpFile)
-		encoder.SetIndent(2)
-		if err := encoder.Encode(&root); err != nil {
-			log.Fatalf("Failed to encode landscape YAML: %v", err)
+		if _, err := tmpFile.WriteString(output); err != nil {
+			log.Fatalf("Failed to write temp file: %v", err)
 		}
-		tmpFile.Close()
+		if err := tmpFile.Close(); err != nil {
+			log.Fatalf("Failed to close temp file: %v", err)
+		}
 
-		// Run diff
 		cmd := exec.Command("diff", "-u", *landscapePath, tmpFile.Name())
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		fmt.Println("--- Diff ---")
-		_ = cmd.Run() // diff returns exit code 1 if files differ, which is expected
+		_ = cmd.Run()
 
-		// Print PR details
 		fmt.Println("\n--- Pull Request Details ---")
 		fmt.Printf("Title: Update %s metadata\n", project.Name)
 		fmt.Printf("Body: Automated update for %s from cncf/automation\n", project.Name)
@@ -87,18 +100,9 @@ func main() {
 	}
 
 	// Save
-	f, err := os.Create(*landscapePath)
-	if err != nil {
-		log.Fatalf("Failed to open landscape file for writing: %v", err)
+	if err := os.WriteFile(*landscapePath, []byte(output), 0644); err != nil {
+		log.Fatalf("Failed to write landscape file: %v", err)
 	}
-	defer f.Close()
-
-	encoder := yaml.NewEncoder(f)
-	encoder.SetIndent(2)
-	if err := encoder.Encode(&root); err != nil {
-		log.Fatalf("Failed to encode landscape YAML: %v", err)
-	}
-	f.Close() // Close explicitly before git operations
 	log.Printf("Successfully updated landscape.yml for project %s", project.Name)
 
 	if *createPR {
@@ -153,7 +157,6 @@ func createPullRequest(landscapePath, landscapeRepo string, project *projects.Pr
 	}
 
 	// Create PR using gh
-	// Check if gh is available
 	if _, err := exec.LookPath("gh"); err != nil {
 		return fmt.Errorf("gh cli not found, cannot create PR")
 	}
@@ -171,15 +174,14 @@ func createPullRequest(landscapePath, landscapeRepo string, project *projects.Pr
 	return nil
 }
 
-func updateLandscape(root *yaml.Node, project *projects.Project) bool {
-	// Navigate to 'landscape' key
+// updateLandscape navigates the YAML node tree to find the matching project
+// entry, then applies line-level edits to the raw file lines.
+func updateLandscape(root *yaml.Node, project *projects.Project, lines []string) ([]string, bool) {
 	if root.Kind != yaml.DocumentNode {
-		return false
+		return lines, false
 	}
 
 	var landscapeSeq *yaml.Node
-
-	// Find "landscape" key in the root map
 	if len(root.Content) > 0 && root.Content[0].Kind == yaml.MappingNode {
 		for i := 0; i < len(root.Content[0].Content); i += 2 {
 			key := root.Content[0].Content[i]
@@ -192,12 +194,10 @@ func updateLandscape(root *yaml.Node, project *projects.Project) bool {
 	}
 
 	if landscapeSeq == nil {
-		return false
+		return lines, false
 	}
 
-	// Iterate through categories
 	for _, categoryNode := range landscapeSeq.Content {
-		// Find "subcategories"
 		var subcategoriesSeq *yaml.Node
 		for i := 0; i < len(categoryNode.Content); i += 2 {
 			key := categoryNode.Content[i]
@@ -207,14 +207,11 @@ func updateLandscape(root *yaml.Node, project *projects.Project) bool {
 				break
 			}
 		}
-
 		if subcategoriesSeq == nil {
 			continue
 		}
 
-		// Iterate through subcategories
 		for _, subcategoryNode := range subcategoriesSeq.Content {
-			// Find "items"
 			var itemsSeq *yaml.Node
 			for i := 0; i < len(subcategoryNode.Content); i += 2 {
 				key := subcategoryNode.Content[i]
@@ -224,28 +221,28 @@ func updateLandscape(root *yaml.Node, project *projects.Project) bool {
 					break
 				}
 			}
-
 			if itemsSeq == nil {
 				continue
 			}
 
-			// Iterate through items
 			for _, itemNode := range itemsSeq.Content {
-				if matchAndUpdateItem(itemNode, project) {
-					return true
+				newLines, matched := matchAndUpdateItem(itemNode, project, lines)
+				if matched {
+					return newLines, true
 				}
 			}
 		}
 	}
 
-	return false
+	return lines, false
 }
 
-func matchAndUpdateItem(itemNode *yaml.Node, project *projects.Project) bool {
+// matchAndUpdateItem checks if the given item node matches the project (by name
+// and repo_url), and if so, detects changes and applies line-level edits.
+func matchAndUpdateItem(itemNode *yaml.Node, project *projects.Project, lines []string) ([]string, bool) {
 	var nameNode *yaml.Node
 	var repoURLNode *yaml.Node
 
-	// Find name and repo_url
 	for i := 0; i < len(itemNode.Content); i += 2 {
 		key := itemNode.Content[i]
 		val := itemNode.Content[i+1]
@@ -257,10 +254,9 @@ func matchAndUpdateItem(itemNode *yaml.Node, project *projects.Project) bool {
 	}
 
 	if nameNode == nil || repoURLNode == nil {
-		return false
+		return lines, false
 	}
 
-	// Check match
 	nameMatch := strings.EqualFold(nameNode.Value, project.Name)
 	repoMatch := false
 	for _, repo := range project.Repositories {
@@ -270,65 +266,49 @@ func matchAndUpdateItem(itemNode *yaml.Node, project *projects.Project) bool {
 		}
 	}
 
-	if nameMatch && repoMatch {
-		return updateItemFields(itemNode, project)
+	if !nameMatch || !repoMatch {
+		return lines, false
 	}
 
-	return false
+	edits := detectChanges(itemNode, project)
+	if len(edits) == 0 {
+		return lines, false
+	}
+
+	newLines := applyItemEdits(lines, edits, itemNode)
+	return newLines, true
 }
 
-func updateItemFields(itemNode *yaml.Node, project *projects.Project) bool {
-	changed := false
-	// Helper to set or add field
-	setField := func(node *yaml.Node, fieldName, value string) {
-		if value == "" {
+// detectChanges compares the YAML node tree values against the project and
+// returns a list of field edits needed. This is read-only on the node tree.
+func detectChanges(itemNode *yaml.Node, project *projects.Project) []fieldEdit {
+	var edits []fieldEdit
+
+	checkField := func(key, newValue string, isExtra bool, node *yaml.Node) {
+		if newValue == "" {
 			return
 		}
 		found := false
 		for i := 0; i < len(node.Content); i += 2 {
-			key := node.Content[i]
-			if key.Value == fieldName {
-				if node.Content[i+1].Value != value {
-					node.Content[i+1].Value = value
-					changed = true
-				}
+			if node.Content[i].Value == key {
 				found = true
+				if node.Content[i+1].Value != newValue {
+					edits = append(edits, fieldEdit{key: key, newValue: newValue, isExtra: isExtra, exists: true})
+				}
 				break
 			}
 		}
 		if !found {
-			node.Content = append(node.Content,
-				&yaml.Node{Kind: yaml.ScalarNode, Value: fieldName},
-				&yaml.Node{Kind: yaml.ScalarNode, Value: value},
-			)
-			changed = true
+			edits = append(edits, fieldEdit{key: key, newValue: newValue, isExtra: isExtra, exists: false})
 		}
 	}
 
-	// Helper to get or create 'extra' node
-	getExtraNode := func() *yaml.Node {
-		for i := 0; i < len(itemNode.Content); i += 2 {
-			key := itemNode.Content[i]
-			if key.Value == "extra" {
-				return itemNode.Content[i+1]
-			}
-		}
-		// Create extra if not found
-		extraNode := &yaml.Node{Kind: yaml.MappingNode}
-		itemNode.Content = append(itemNode.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Value: "extra"},
-			extraNode,
-		)
-		changed = true
-		return extraNode
-	}
+	// Top-level fields
+	checkField("homepage_url", project.Website, false, itemNode)
+	checkField("description", project.Description, false, itemNode)
 
-	setField(itemNode, "homepage_url", project.Website)
-	setField(itemNode, "description", project.Description)
-
-	// Top level social fields
 	if val, ok := project.Social["twitter"]; ok {
-		setField(itemNode, "twitter", val)
+		checkField("twitter", val, false, itemNode)
 	}
 
 	// Extra fields
@@ -338,7 +318,6 @@ func updateItemFields(itemNode *yaml.Node, project *projects.Project) bool {
 		"youtube":  "youtube_url",
 	}
 
-	// Check if we need to update extra fields
 	needsExtra := false
 	for key := range extraMappings {
 		if _, ok := project.Social[key]; ok {
@@ -348,13 +327,266 @@ func updateItemFields(itemNode *yaml.Node, project *projects.Project) bool {
 	}
 
 	if needsExtra {
-		extraNode := getExtraNode()
-		for key, landscapeKey := range extraMappings {
-			if val, ok := project.Social[key]; ok {
-				setField(extraNode, landscapeKey, val)
+		var extraNode *yaml.Node
+		for i := 0; i < len(itemNode.Content); i += 2 {
+			if itemNode.Content[i].Value == "extra" {
+				extraNode = itemNode.Content[i+1]
+				break
+			}
+		}
+
+		for socialKey, landscapeKey := range extraMappings {
+			val, ok := project.Social[socialKey]
+			if !ok || val == "" {
+				continue
+			}
+			if extraNode != nil {
+				checkField(landscapeKey, val, true, extraNode)
+			} else {
+				edits = append(edits, fieldEdit{key: landscapeKey, newValue: val, isExtra: true, exists: false})
 			}
 		}
 	}
 
-	return changed
+	return edits
+}
+
+// applyItemEdits applies the detected field edits to the raw file lines.
+// Updates are applied first (they may shrink lines by collapsing block scalars),
+// then inserts are applied (they grow lines).
+func applyItemEdits(lines []string, edits []fieldEdit, itemNode *yaml.Node) []string {
+	result := make([]string, len(lines))
+	copy(result, lines)
+
+	start, end := getItemLineRange(result, itemNode)
+	fieldIndent := detectFieldIndent(result, start, end)
+	extraIndent := fieldIndent + 2
+
+	// Apply updates first (may change line count if collapsing block scalars)
+	for _, edit := range edits {
+		if !edit.exists {
+			continue
+		}
+		indent := fieldIndent
+		if edit.isExtra {
+			indent = extraIndent
+		}
+		result, end = replaceFieldInLines(result, start, end, edit.key, edit.newValue, indent)
+	}
+
+	// Apply inserts (each insert shifts subsequent lines)
+	for _, edit := range edits {
+		if edit.exists {
+			continue
+		}
+		indent := fieldIndent
+		if edit.isExtra {
+			indent = extraIndent
+		}
+		result, end = insertFieldInLines(result, start, end, edit.key, edit.newValue, indent, edit.isExtra, fieldIndent)
+	}
+
+	return result
+}
+
+// getItemLineRange returns the 0-indexed start and end (exclusive) line indices
+// for the given item node within the lines slice.
+func getItemLineRange(lines []string, itemNode *yaml.Node) (start, end int) {
+	start = itemNode.Line - 1 // convert 1-indexed to 0-indexed
+
+	// Detect the indent of the "- " sequence marker on the start line
+	dashPos := strings.Index(lines[start], "- ")
+	if dashPos < 0 {
+		dashPos = 0
+	}
+
+	for i := start + 1; i < len(lines); i++ {
+		trimmed := strings.TrimLeft(lines[i], " ")
+		if trimmed == "" || trimmed == "\r" {
+			continue
+		}
+		indent := len(lines[i]) - len(trimmed)
+		if indent <= dashPos {
+			return start, i
+		}
+	}
+	return start, len(lines)
+}
+
+// detectFieldIndent determines the indentation level for top-level fields
+// within an item by examining the lines after the sequence marker line.
+func detectFieldIndent(lines []string, start, end int) int {
+	for i := start + 1; i < end && i < len(lines); i++ {
+		trimmed := strings.TrimLeft(lines[i], " ")
+		if trimmed == "" {
+			continue
+		}
+		return len(lines[i]) - len(trimmed)
+	}
+	// Fallback: start line indent + 2
+	trimmed := strings.TrimLeft(lines[start], " ")
+	return len(lines[start]) - len(trimmed) + 2
+}
+
+// findFieldLine returns the 0-indexed line number where the given key appears
+// at the specified indentation, or -1 if not found.
+func findFieldLine(lines []string, start, end int, key string, indent int) int {
+	prefix := strings.Repeat(" ", indent) + key + ":"
+	for i := start; i < end && i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], prefix) {
+			rest := lines[i][len(prefix):]
+			if rest == "" || rest[0] == ' ' || rest[0] == '\r' || rest[0] == '\n' {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// findExtraBlockEnd returns the line index (exclusive) where the extra block
+// ends. It scans from after the extra: key line for lines indented at or beyond
+// extraIndent.
+func findExtraBlockEnd(lines []string, extraKeyLine, itemEnd, extraIndent int) int {
+	last := extraKeyLine
+	for i := extraKeyLine + 1; i < itemEnd && i < len(lines); i++ {
+		trimmed := strings.TrimLeft(lines[i], " ")
+		if trimmed == "" {
+			continue
+		}
+		lineIndent := len(lines[i]) - len(trimmed)
+		if lineIndent >= extraIndent {
+			last = i
+		} else {
+			break
+		}
+	}
+	return last + 1
+}
+
+// findLastFieldLine returns the index of the last non-blank line within the
+// item that has indentation >= fieldIndent.
+func findLastFieldLine(lines []string, start, end, fieldIndent int) int {
+	last := start
+	for i := start; i < end && i < len(lines); i++ {
+		trimmed := strings.TrimLeft(lines[i], " ")
+		if trimmed == "" {
+			continue
+		}
+		lineIndent := len(lines[i]) - len(trimmed)
+		if lineIndent >= fieldIndent {
+			last = i
+		}
+	}
+	return last
+}
+
+// replaceFieldInLines replaces the value of an existing field in the raw lines.
+// Handles block scalars (>-, >, |, |-) by collapsing continuation lines.
+func replaceFieldInLines(lines []string, start, end int, key, newValue string, indent int) ([]string, int) {
+	lineIdx := findFieldLine(lines, start, end, key, indent)
+	if lineIdx < 0 {
+		return lines, end
+	}
+
+	prefix := strings.Repeat(" ", indent) + key + ":"
+	valuePart := strings.TrimSpace(lines[lineIdx][len(prefix):])
+
+	isBlockScalar := valuePart == ">" || valuePart == ">-" || valuePart == "|" || valuePart == "|-"
+
+	// Replace the key line with the new simple scalar value
+	lines[lineIdx] = strings.Repeat(" ", indent) + key + ": " + yamlQuoteIfNeeded(newValue)
+
+	if isBlockScalar {
+		// Remove continuation lines (lines indented more than the key)
+		contStart := lineIdx + 1
+		contEnd := contStart
+		for contEnd < end && contEnd < len(lines) {
+			trimmed := strings.TrimLeft(lines[contEnd], " ")
+			if trimmed == "" {
+				break
+			}
+			lineIndent := len(lines[contEnd]) - len(trimmed)
+			if lineIndent > indent {
+				contEnd++
+			} else {
+				break
+			}
+		}
+		if contEnd > contStart {
+			lines = append(lines[:contStart], lines[contEnd:]...)
+			end -= (contEnd - contStart)
+		}
+	}
+
+	return lines, end
+}
+
+// insertFieldInLines inserts a new field line at the appropriate position.
+// For top-level fields, inserts before extra: (if present) or at end of item.
+// For extra fields, inserts at end of extra block, creating extra: if needed.
+func insertFieldInLines(lines []string, start, end int, key, newValue string, indent int, isExtra bool, fieldIndent int) ([]string, int) {
+	newLine := strings.Repeat(" ", indent) + key + ": " + yamlQuoteIfNeeded(newValue)
+
+	var insertAt int
+
+	if isExtra {
+		extraLine := findFieldLine(lines, start, end, "extra", fieldIndent)
+		if extraLine >= 0 {
+			insertAt = findExtraBlockEnd(lines, extraLine, end, fieldIndent+2)
+		} else {
+			// Create extra: block
+			extraKeyLine := strings.Repeat(" ", fieldIndent) + "extra:"
+			insertPos := findLastFieldLine(lines, start, end, fieldIndent) + 1
+			lines = insertLine(lines, insertPos, extraKeyLine)
+			end++
+			insertAt = insertPos + 1
+		}
+	} else {
+		extraLine := findFieldLine(lines, start, end, "extra", fieldIndent)
+		if extraLine >= 0 {
+			insertAt = extraLine
+		} else {
+			insertAt = findLastFieldLine(lines, start, end, fieldIndent) + 1
+		}
+	}
+
+	lines = insertLine(lines, insertAt, newLine)
+	end++
+
+	return lines, end
+}
+
+// insertLine inserts a new line at the given position in the slice.
+func insertLine(lines []string, at int, line string) []string {
+	lines = append(lines, "")
+	copy(lines[at+1:], lines[at:])
+	lines[at] = line
+	return lines
+}
+
+// yamlQuoteIfNeeded returns the value with YAML quoting applied if the value
+// contains characters that require it (e.g. ": ", " #", or special starters).
+func yamlQuoteIfNeeded(value string) string {
+	if value == "" {
+		return "''"
+	}
+
+	needsQuoting := false
+
+	if strings.Contains(value, ": ") || strings.Contains(value, " #") {
+		needsQuoting = true
+	}
+
+	specialStarts := "&*!|>'\"%@`{}[],?"
+	if strings.ContainsAny(string(value[0]), specialStarts) {
+		needsQuoting = true
+	}
+
+	if !needsQuoting {
+		return value
+	}
+
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
 }

--- a/utilities/dot-project/cmd/landscape-updater/main_test.go
+++ b/utilities/dot-project/cmd/landscape-updater/main_test.go
@@ -9,24 +9,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestUpdateLandscape(t *testing.T) {
-	// Setup mock landscape
-	landscapeYAML := `
-landscape:
-  - category: Orchestration & Management
-    subcategories:
-      - items:
-          - name: Kubernetes
-            repo_url: https://github.com/kubernetes/kubernetes
-            homepage_url: https://old.kubernetes.io
-            description: Old description
-`
+func setupTest(landscapeYAML string) (*yaml.Node, []string) {
 	var root yaml.Node
 	if err := yaml.Unmarshal([]byte(landscapeYAML), &root); err != nil {
-		t.Fatalf("Failed to parse mock landscape: %v", err)
+		panic("Failed to parse test landscape YAML: " + err.Error())
 	}
+	lines := strings.Split(landscapeYAML, "\n")
+	return &root, lines
+}
 
-	// Setup mock project
+func TestUpdateLandscape(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Orchestration & Management
+    subcategories:
+      - subcategory:
+        name: Scheduling
+        items:
+          - item:
+            name: Kubernetes
+            repo_url: https://github.com/kubernetes/kubernetes
+            homepage_url: https://old.kubernetes.io
+            description: Old description`
+
+	root, lines := setupTest(landscapeYAML)
+
 	project := &projects.Project{
 		Name:        "Kubernetes",
 		Description: "New description",
@@ -41,19 +48,13 @@ landscape:
 		},
 	}
 
-	// Run update
-	updated := updateLandscape(&root, project)
+	newLines, updated := updateLandscape(root, project, lines)
 	if !updated {
 		t.Fatal("Expected update to return true")
 	}
 
-	// Verify update
-	out, err := yaml.Marshal(&root)
-	if err != nil {
-		t.Fatalf("Failed to marshal updated landscape: %v", err)
-	}
+	outStr := strings.Join(newLines, "\n")
 
-	outStr := string(out)
 	if !strings.Contains(outStr, "homepage_url: https://kubernetes.io") {
 		t.Errorf("Homepage URL not updated. Got:\n%s", outStr)
 	}
@@ -64,9 +65,908 @@ landscape:
 		t.Errorf("Twitter not added. Got:\n%s", outStr)
 	}
 	if !strings.Contains(outStr, "slack_url: https://kubernetes.slack.com") {
-		t.Errorf("Slack URL not added/mapped. Got:\n%s", outStr)
+		t.Errorf("Slack URL not added. Got:\n%s", outStr)
 	}
 	if !strings.Contains(outStr, "linkedin_url: https://linkedin.com/company/kubernetes") {
-		t.Errorf("LinkedIn URL not added/mapped. Got:\n%s", outStr)
+		t.Errorf("LinkedIn URL not added. Got:\n%s", outStr)
+	}
+}
+
+func TestNoChanges(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Orchestration
+    subcategories:
+      - subcategory:
+        name: Scheduling
+        items:
+          - item:
+            name: MyProject
+            repo_url: https://github.com/org/myproject
+            homepage_url: https://myproject.io
+            description: My project description
+            twitter: https://twitter.com/myproject`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:        "MyProject",
+		Description: "My project description",
+		Website:     "https://myproject.io",
+		Repositories: []string{
+			"https://github.com/org/myproject",
+		},
+		Social: map[string]string{
+			"twitter": "https://twitter.com/myproject",
+		},
+	}
+
+	_, updated := updateLandscape(root, project, lines)
+	if updated {
+		t.Fatal("Expected no update when values are identical")
+	}
+}
+
+func TestUpdateExistingField(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Cat
+    subcategories:
+      - subcategory:
+        name: Sub
+        items:
+          - item:
+            name: Proj
+            repo_url: https://github.com/org/proj
+            homepage_url: https://old.proj.io
+            description: Old desc`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:        "Proj",
+		Description: "Old desc",
+		Website:     "https://new.proj.io",
+		Repositories: []string{
+			"https://github.com/org/proj",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "homepage_url: https://new.proj.io") {
+		t.Errorf("Homepage URL not updated. Got:\n%s", outStr)
+	}
+	// Description should remain unchanged
+	if !strings.Contains(outStr, "description: Old desc") {
+		t.Errorf("Description should not have changed. Got:\n%s", outStr)
+	}
+}
+
+func TestInsertNewField(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Cat
+    subcategories:
+      - subcategory:
+        name: Sub
+        items:
+          - item:
+            name: Proj
+            repo_url: https://github.com/org/proj
+            homepage_url: https://proj.io`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:        "Proj",
+		Description: "A new description",
+		Website:     "https://proj.io",
+		Repositories: []string{
+			"https://github.com/org/proj",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update for new description")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "description: A new description") {
+		t.Errorf("Description not inserted. Got:\n%s", outStr)
+	}
+	// homepage_url should be unchanged
+	if !strings.Contains(outStr, "homepage_url: https://proj.io") {
+		t.Errorf("Homepage URL should not have changed. Got:\n%s", outStr)
+	}
+}
+
+func TestUpdateExtraField(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Cat
+    subcategories:
+      - subcategory:
+        name: Sub
+        items:
+          - item:
+            name: Proj
+            repo_url: https://github.com/org/proj
+            homepage_url: https://proj.io
+            extra:
+              slack_url: https://old-slack.com`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:    "Proj",
+		Website: "https://proj.io",
+		Repositories: []string{
+			"https://github.com/org/proj",
+		},
+		Social: map[string]string{
+			"slack": "https://new-slack.com",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update for extra field")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "slack_url: https://new-slack.com") {
+		t.Errorf("Slack URL not updated. Got:\n%s", outStr)
+	}
+}
+
+func TestInsertNewExtraField(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Cat
+    subcategories:
+      - subcategory:
+        name: Sub
+        items:
+          - item:
+            name: Proj
+            repo_url: https://github.com/org/proj
+            homepage_url: https://proj.io
+            extra:
+              slack_url: https://slack.com`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:    "Proj",
+		Website: "https://proj.io",
+		Repositories: []string{
+			"https://github.com/org/proj",
+		},
+		Social: map[string]string{
+			"slack":    "https://slack.com",
+			"linkedin": "https://linkedin.com/proj",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update for new extra field")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "linkedin_url: https://linkedin.com/proj") {
+		t.Errorf("LinkedIn URL not inserted. Got:\n%s", outStr)
+	}
+	// Existing slack_url should be unchanged
+	if !strings.Contains(outStr, "slack_url: https://slack.com") {
+		t.Errorf("Existing slack_url should not have changed. Got:\n%s", outStr)
+	}
+}
+
+func TestCreateExtraBlock(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Cat
+    subcategories:
+      - subcategory:
+        name: Sub
+        items:
+          - item:
+            name: Proj
+            repo_url: https://github.com/org/proj
+            homepage_url: https://proj.io`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:    "Proj",
+		Website: "https://proj.io",
+		Repositories: []string{
+			"https://github.com/org/proj",
+		},
+		Social: map[string]string{
+			"slack": "https://slack.com/proj",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update for new extra block")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "extra:") {
+		t.Errorf("extra: block not created. Got:\n%s", outStr)
+	}
+	if !strings.Contains(outStr, "slack_url: https://slack.com/proj") {
+		t.Errorf("Slack URL not inserted under extra. Got:\n%s", outStr)
+	}
+}
+
+func TestMultiLineDescriptionReplacement(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Cat
+    subcategories:
+      - subcategory:
+        name: Sub
+        items:
+          - item:
+            name: Proj
+            repo_url: https://github.com/org/proj
+            description: >-
+              This is a long description that
+              spans multiple lines
+            homepage_url: https://proj.io`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:        "Proj",
+		Description: "Short new description",
+		Website:     "https://proj.io",
+		Repositories: []string{
+			"https://github.com/org/proj",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update for multi-line description")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "description: Short new description") {
+		t.Errorf("Description not replaced. Got:\n%s", outStr)
+	}
+	// The multi-line continuation should be gone
+	if strings.Contains(outStr, "spans multiple lines") {
+		t.Errorf("Multi-line continuation lines should have been removed. Got:\n%s", outStr)
+	}
+	// homepage_url should still be there
+	if !strings.Contains(outStr, "homepage_url: https://proj.io") {
+		t.Errorf("homepage_url should not have been removed. Got:\n%s", outStr)
+	}
+}
+
+func TestUnrelatedLinesUntouched(t *testing.T) {
+	landscapeYAML := `landscape:
+  - category:
+    name: Cat
+    subcategories:
+      - subcategory:
+        name: Sub
+        items:
+          - item:
+            name: Other
+            repo_url: https://github.com/org/other
+            homepage_url: https://other.io
+            description: Other project
+          - item:
+            name: Target
+            repo_url: https://github.com/org/target
+            homepage_url: https://old.target.io
+          - item:
+            name: Another
+            repo_url: https://github.com/org/another
+            homepage_url: https://another.io
+            description: Another project`
+
+	root, lines := setupTest(landscapeYAML)
+
+	project := &projects.Project{
+		Name:    "Target",
+		Website: "https://new.target.io",
+		Repositories: []string{
+			"https://github.com/org/target",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	// Verify target item was updated
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "homepage_url: https://new.target.io") {
+		t.Errorf("Target homepage_url not updated. Got:\n%s", outStr)
+	}
+
+	// Verify other items are byte-for-byte identical
+	for i := range newLines {
+		if i < len(lines) && lines[i] != newLines[i] {
+			// Only the target item's homepage_url line should differ
+			if !strings.Contains(lines[i], "old.target.io") {
+				t.Errorf("Line %d was modified unexpectedly.\nOriginal: %q\nModified: %q", i+1, lines[i], newLines[i])
+			}
+		}
+	}
+}
+
+// realisticLandscapeYAML simulates the real cncf/landscape landscape.yml with
+// the exact noise patterns that caused issues in PRs #4820-#4829:
+// - Trailing whitespace on various lines
+// - Multi-line >- descriptions on unrelated items
+// - Empty description with trailing space
+// - Multiple items across categories
+const realisticLandscapeYAML = `landscape:
+  - category:
+    name: Provisioning
+    subcategories:
+      - subcategory:
+        name: Automation & Configuration
+        items:
+          - item:
+            name: Meshery
+            homepage_url: https://meshery.io
+            project: sandbox
+            repo_url: https://github.com/meshery/meshery
+            logo: meshery.svg
+            twitter: https://twitter.com/mesheryio
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            allow_duplicate_repo: true
+            extra:
+              lfx_slug: meshery
+              accepted: '2021-06-22'
+              slack_url: https://slack.meshery.io
+              linkedin_url: https://www.linkedin.com/showcase/meshery
+              youtube_url: https://www.youtube.com/@mesheryio
+              clomonitor_name: meshery
+          - item:
+            name: SomeOther
+            homepage_url: https://someother.io
+            repo_url: https://github.com/org/someother
+            logo: someother.svg
+            crunchbase: https://www.crunchbase.com/organization/someother
+  - category:
+    name: Runtime
+    subcategories:
+      - subcategory:
+        name: Cloud Native Storage
+        items:
+          - item:
+            name: OpenEBS
+            homepage_url: https://www.openebs.io/
+            project: sandbox
+            repo_url: https://github.com/openebs/openebs
+            logo: openebs.svg
+            twitter: https://twitter.com/openebs
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              slack_url: https://cloud-native.slack.com/archives/CSL0PJ8GN
+              youtube_url: https://www.youtube.com/channel/UC3ywadaAUQ1FI4YsHZ8wa0g
+              clomonitor_name: openebs
+  - category:
+    name: Orchestration & Management
+    subcategories:
+      - subcategory:
+        name: Scheduling & Orchestration
+        items:
+          - item:
+            name: MSAP.ai
+            description: >-
+              MSAP.ai(Container Orchestration Platform) is a next-generation application operations platform that simplify complexity and support business innovation in
+              cloud-native environment built on Kubernetes. It maximizes the value of Kubernetes adoption for enterprises while minimizing operational costs.
+            homepage_url: https://www.openmaru.io
+            logo: msap.ai.svg
+            crunchbase: https://www.crunchbase.com/organization/openmaru
+          - item:
+            name: Open Cluster Management
+            homepage_url: https://open-cluster-management.io/
+            project: sandbox
+            repo_url: https://github.com/open-cluster-management-io/ocm
+            logo: open-cluster-management.svg
+            twitter: https://twitter.com/ocm_io
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              slack_url: https://kubernetes.slack.com/archives/C01GE7YSUUF
+              youtube_url: https://www.youtube.com/channel/UC7xxOh2jBM5Jfwt3fsBzOZw
+              clomonitor_name: ocm
+          - item:
+            name: kcp
+            homepage_url: https://kcp.io
+            project: sandbox
+            repo_url: https://github.com/kcp-dev/kcp
+            logo: kcp.svg
+            twitter: https://twitter.com/kcp
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              slack_url: http://slack.k8s.io/
+              clomonitor_name: kcp
+          - item:
+            name: plusserver Kubernetes Engine (PSKE)
+            description: >-
+              The plusserver Kubernetes Engine (PSKE) based on Gardener reduces the complexity in managing multi-cloud environments
+              and enables companies to orchestrate their containers and cloud-native applications across a variety of platforms such
+              as plusserver's pluscloud open or hyperscalers such as AWS, either by mouseclick or via an API.
+            homepage_url: https://www.plusserver.com/en/product/managed-kubernetes/
+            logo: plusserver.svg
+            crunchbase: https://www.crunchbase.com/organization/plusserver
+          - item:
+            name: k0s
+            homepage_url: https://k0sproject.io/
+            project: sandbox
+            repo_url: https://github.com/k0sproject/k0s
+            logo: k0s-logo-2025.svg
+            twitter: https://x.com/k0sproject
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              slack_url: http://slack.k8s.io/
+              clomonitor_name: k0s
+          - item:
+            name: ORAS
+            homepage_url: https://oras.land/
+            project: sandbox
+            repo_url: https://github.com/oras-project/oras
+            logo: oras.svg
+            twitter: https://twitter.com/orasproject
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              slack_url: https://cloud-native.slack.com/messages/oras
+              clomonitor_name: oras
+  - category:
+    name: Members
+    subcategories:
+      - subcategory:
+        name: General
+        items:
+          - item:
+            name: F5 (member)
+            homepage_url: https://www.f5.com
+            logo: f5-member.svg
+            twitter: https://twitter.com/F5
+            crunchbase: https://www.crunchbase.com/organization/f5-networks
+            joined: '2017-11-01'
+          - item:
+            name: Breqwatr (member)
+            homepage_url: https://www.breqwatr.com
+            logo: breqwatr.svg
+            crunchbase: https://www.crunchbase.com/organization/breqwatr
+            joined: '2026-04-01'
+          - item:
+            name: Volcano-Kthena
+            description:
+            homepage_url: https://volcano.sh/
+            project: incubating
+            repo_url: https://github.com/volcano-sh/kthena
+          - item:
+            name: vLLM
+            logo: ./vllm-logo-text-light.svg
+            unnamed_organization: true
+            homepage_url: https://docs.vllm.ai/en/latest/
+         `
+
+// injectTrailingWhitespace adds trailing spaces to specific lines in the
+// landscape YAML to simulate the real cncf/landscape file patterns.
+// This is done programmatically because editors strip trailing whitespace.
+func injectTrailingWhitespace(lines []string) []string {
+	result := make([]string, len(lines))
+	copy(result, lines)
+	for i, line := range result {
+		// Simulate trailing whitespace on crunchbase/joined lines (from PRs)
+		if strings.Contains(line, "crunchbase: https://www.crunchbase.com/organization/someother") ||
+			strings.Contains(line, "joined: '2017-11-01'") ||
+			strings.Contains(line, "joined: '2026-04-01'") {
+			result[i] = line + "            "
+		}
+		// Simulate empty description with trailing space (Volcano-Kthena pattern)
+		if strings.TrimSpace(line) == "description:" && strings.Contains(lines[i+1], "homepage_url: https://volcano.sh/") {
+			result[i] = line + " "
+		}
+	}
+	return result
+}
+
+// setupTestWithNoise parses YAML and injects real-world trailing whitespace
+// patterns to simulate the upstream cncf/landscape file.
+func setupTestWithNoise(landscapeYAML string) (*yaml.Node, []string) {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(landscapeYAML), &root); err != nil {
+		panic("Failed to parse test landscape YAML: " + err.Error())
+	}
+	lines := strings.Split(landscapeYAML, "\n")
+	lines = injectTrailingWhitespace(lines)
+	return &root, lines
+}
+
+// findLine returns the 0-indexed line number containing substr, or -1.
+func findLine(lines []string, substr string) int {
+	for i, l := range lines {
+		if strings.Contains(l, substr) {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestPR4820_Meshery simulates PR #4820: add description to Meshery.
+// The landscape contains trailing whitespace and multi-line >- descriptions
+// on unrelated items that must NOT be modified.
+func TestPR4820_Meshery(t *testing.T) {
+	root, lines := setupTestWithNoise(realisticLandscapeYAML)
+
+	project := &projects.Project{
+		Name:        "Meshery",
+		Description: "Infrastructure by Design",
+		Website:     "https://meshery.io",
+		Repositories: []string{
+			"https://github.com/meshery/meshery",
+		},
+		Social: map[string]string{
+			"twitter": "https://twitter.com/mesheryio",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+
+	// The description should be added
+	if !strings.Contains(outStr, "description: Infrastructure by Design") {
+		t.Errorf("Meshery description not added. Got:\n%s", outStr)
+	}
+
+	// Exactly 1 line should be added (the description)
+	if len(newLines) != len(lines)+1 {
+		t.Errorf("Expected exactly 1 line added, got %d lines changed (original=%d, new=%d)",
+			len(newLines)-len(lines), len(lines), len(newLines))
+	}
+
+	// All noise patterns must be preserved as-is
+	assertNoisePreserved(t, newLines)
+}
+
+// TestPR4821_OpenEBS simulates PR #4821: add description to OpenEBS.
+func TestPR4821_OpenEBS(t *testing.T) {
+	root, lines := setupTestWithNoise(realisticLandscapeYAML)
+
+	project := &projects.Project{
+		Name:        "OpenEBS",
+		Description: "Open Source Container Attached Storage, built using Cloud Native Architecture, simplifies running Stateful Applications on Kubernetes",
+		Website:     "https://www.openebs.io/",
+		Repositories: []string{
+			"https://github.com/openebs/openebs",
+		},
+		Social: map[string]string{
+			"twitter": "https://twitter.com/openebs",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "description: Open Source Container Attached Storage") {
+		t.Errorf("OpenEBS description not added. Got:\n%s", outStr)
+	}
+
+	if len(newLines) != len(lines)+1 {
+		t.Errorf("Expected exactly 1 line added, got delta=%d", len(newLines)-len(lines))
+	}
+
+	assertNoisePreserved(t, newLines)
+}
+
+// TestPR4822_OCM simulates PR #4822: add description to Open Cluster Management.
+func TestPR4822_OCM(t *testing.T) {
+	root, lines := setupTestWithNoise(realisticLandscapeYAML)
+
+	project := &projects.Project{
+		Name:        "Open Cluster Management",
+		Description: "Make working with many Kubernetes clusters super easy regardless of where they are deployed",
+		Website:     "https://open-cluster-management.io/",
+		Repositories: []string{
+			"https://github.com/open-cluster-management-io/ocm",
+		},
+		Social: map[string]string{
+			"twitter": "https://twitter.com/ocm_io",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "description: Make working with many Kubernetes clusters") {
+		t.Errorf("OCM description not added. Got:\n%s", outStr)
+	}
+
+	if len(newLines) != len(lines)+1 {
+		t.Errorf("Expected exactly 1 line added, got delta=%d", len(newLines)-len(lines))
+	}
+
+	assertNoisePreserved(t, newLines)
+}
+
+// TestPR4823_kcp simulates PR #4823: add description to kcp.
+func TestPR4823_kcp(t *testing.T) {
+	root, lines := setupTestWithNoise(realisticLandscapeYAML)
+
+	project := &projects.Project{
+		Name:        "kcp",
+		Description: "Kubernetes-like control planes for form-factors and use-cases beyond Kubernetes and container workloads.",
+		Website:     "https://kcp.io",
+		Repositories: []string{
+			"https://github.com/kcp-dev/kcp",
+		},
+		Social: map[string]string{
+			"twitter": "https://twitter.com/kcp",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "description: Kubernetes-like control planes") {
+		t.Errorf("kcp description not added. Got:\n%s", outStr)
+	}
+
+	if len(newLines) != len(lines)+1 {
+		t.Errorf("Expected exactly 1 line added, got delta=%d", len(newLines)-len(lines))
+	}
+
+	assertNoisePreserved(t, newLines)
+}
+
+// TestPR4827_ORAS simulates PR #4827: add description to ORAS.
+func TestPR4827_ORAS(t *testing.T) {
+	root, lines := setupTestWithNoise(realisticLandscapeYAML)
+
+	project := &projects.Project{
+		Name:        "ORAS",
+		Description: "ORAS is the tool for working with OCI Artifacts",
+		Website:     "https://oras.land/",
+		Repositories: []string{
+			"https://github.com/oras-project/oras",
+		},
+		Social: map[string]string{
+			"twitter": "https://twitter.com/orasproject",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "description: ORAS is the tool for working with OCI Artifacts") {
+		t.Errorf("ORAS description not added. Got:\n%s", outStr)
+	}
+
+	if len(newLines) != len(lines)+1 {
+		t.Errorf("Expected exactly 1 line added, got delta=%d", len(newLines)-len(lines))
+	}
+
+	assertNoisePreserved(t, newLines)
+}
+
+// TestPR4829_k0s simulates PR #4829: add description to k0s.
+func TestPR4829_k0s(t *testing.T) {
+	root, lines := setupTestWithNoise(realisticLandscapeYAML)
+
+	project := &projects.Project{
+		Name:        "k0s",
+		Description: "k0s is a CNCF-certified lightweight, Kubernetes distribution with zero dependencies and zero opinion.",
+		Website:     "https://k0sproject.io/",
+		Repositories: []string{
+			"https://github.com/k0sproject/k0s",
+		},
+		Social: map[string]string{
+			"twitter": "https://x.com/k0sproject",
+		},
+	}
+
+	newLines, updated := updateLandscape(root, project, lines)
+	if !updated {
+		t.Fatal("Expected update")
+	}
+
+	outStr := strings.Join(newLines, "\n")
+	if !strings.Contains(outStr, "description: k0s is a CNCF-certified lightweight") {
+		t.Errorf("k0s description not added. Got:\n%s", outStr)
+	}
+
+	if len(newLines) != len(lines)+1 {
+		t.Errorf("Expected exactly 1 line added, got delta=%d", len(newLines)-len(lines))
+	}
+
+	assertNoisePreserved(t, newLines)
+}
+
+// assertNoisePreserved checks that all the known noise-inducing patterns from
+// the real landscape.yml are preserved byte-for-byte in the output.
+func assertNoisePreserved(t *testing.T, lines []string) {
+	t.Helper()
+	outStr := strings.Join(lines, "\n")
+
+	// 1. Trailing whitespace on unrelated entries must be preserved
+	// (injected by injectTrailingWhitespace to simulate real landscape.yml)
+	trailingWS := []string{
+		"organization/someother            ",
+		"'2017-11-01'            ",
+		"'2026-04-01'            ",
+	}
+	for _, pattern := range trailingWS {
+		if !strings.Contains(outStr, pattern) {
+			t.Errorf("Trailing whitespace was stripped from unrelated line.\n  Expected to find: %q", pattern)
+		}
+	}
+
+	// 2. Multi-line >- descriptions must NOT be collapsed
+	multiLinePatterns := []string{
+		"description: >-",
+		"cloud-native environment built on Kubernetes. It maximizes",
+		"and enables companies to orchestrate their containers",
+		"as plusserver's pluscloud open or hyperscalers such as AWS",
+	}
+	for _, pattern := range multiLinePatterns {
+		if !strings.Contains(outStr, pattern) {
+			t.Errorf("Multi-line description was modified.\n  Expected to find: %q", pattern)
+		}
+	}
+
+	// 3. Empty description with trailing space (Volcano-Kthena) must be preserved
+	volcanoDescLine := findLine(lines, "volcano.sh")
+	if volcanoDescLine > 0 {
+		prevLine := lines[volcanoDescLine-1]
+		if !strings.HasSuffix(prevLine, " ") {
+			t.Errorf("Volcano-Kthena empty description trailing space was stripped: %q", prevLine)
+		}
+	}
+
+	// 4. Trailing whitespace at end of file (vLLM entry) must be preserved
+	if !strings.Contains(outStr, "homepage_url: https://docs.vllm.ai/en/latest/\n         ") {
+		t.Errorf("Trailing content after vLLM entry was modified")
+	}
+}
+
+// TestAllPRsNoNoiseRegression runs all 6 projects against the same landscape
+// and verifies that ONLY the target project lines differ each time.
+func TestAllPRsNoNoiseRegression(t *testing.T) {
+	prProjects := []struct {
+		name string
+		proj projects.Project
+	}{
+		{"Meshery", projects.Project{
+			Name: "Meshery", Description: "Infrastructure by Design",
+			Website: "https://meshery.io", Repositories: []string{"https://github.com/meshery/meshery"},
+			Social: map[string]string{"twitter": "https://twitter.com/mesheryio"},
+		}},
+		{"OpenEBS", projects.Project{
+			Name: "OpenEBS", Description: "Container Attached Storage",
+			Website: "https://www.openebs.io/", Repositories: []string{"https://github.com/openebs/openebs"},
+			Social: map[string]string{"twitter": "https://twitter.com/openebs"},
+		}},
+		{"Open Cluster Management", projects.Project{
+			Name: "Open Cluster Management", Description: "Multi-cluster management",
+			Website: "https://open-cluster-management.io/", Repositories: []string{"https://github.com/open-cluster-management-io/ocm"},
+			Social: map[string]string{"twitter": "https://twitter.com/ocm_io"},
+		}},
+		{"kcp", projects.Project{
+			Name: "kcp", Description: "Kubernetes-like control planes",
+			Website: "https://kcp.io", Repositories: []string{"https://github.com/kcp-dev/kcp"},
+			Social: map[string]string{"twitter": "https://twitter.com/kcp"},
+		}},
+		{"ORAS", projects.Project{
+			Name: "ORAS", Description: "OCI Artifacts tool",
+			Website: "https://oras.land/", Repositories: []string{"https://github.com/oras-project/oras"},
+			Social: map[string]string{"twitter": "https://twitter.com/orasproject"},
+		}},
+		{"k0s", projects.Project{
+			Name: "k0s", Description: "Lightweight Kubernetes distribution",
+			Website: "https://k0sproject.io/", Repositories: []string{"https://github.com/k0sproject/k0s"},
+			Social: map[string]string{"twitter": "https://x.com/k0sproject"},
+		}},
+	}
+
+	for _, tc := range prProjects {
+		t.Run(tc.name, func(t *testing.T) {
+			root, origLines := setupTestWithNoise(realisticLandscapeYAML)
+			proj := tc.proj
+
+			newLines, updated := updateLandscape(root, &proj, origLines)
+			if !updated {
+				t.Fatalf("Expected update for %s", tc.name)
+			}
+
+			// Count changed lines (excluding inserted lines)
+			changedCount := 0
+			minLen := len(origLines)
+			if len(newLines) < minLen {
+				minLen = len(newLines)
+			}
+
+			insertedLines := len(newLines) - len(origLines)
+
+			// Find where the insertion happened
+			insertionPoint := -1
+			for i := 0; i < minLen; i++ {
+				if origLines[i] != newLines[i] {
+					insertionPoint = i
+					break
+				}
+			}
+
+			if insertionPoint >= 0 {
+				// Verify lines after the insertion are unchanged
+				for i := insertionPoint; i < len(origLines); i++ {
+					j := i + insertedLines
+					if j < len(newLines) && origLines[i] != newLines[j] {
+						changedCount++
+						t.Errorf("Line %d changed unexpectedly for %s.\n  Original: %q\n  Modified: %q",
+							i+1, tc.name, origLines[i], newLines[j])
+					}
+				}
+			}
+
+			// Should only have inserted lines (description), no modifications to existing lines
+			if changedCount > 0 {
+				t.Errorf("%s: %d existing lines were modified (expected 0)", tc.name, changedCount)
+			}
+
+			// Should have added exactly 1 line (the description)
+			if insertedLines != 1 {
+				t.Errorf("%s: expected 1 inserted line, got %d", tc.name, insertedLines)
+			}
+		})
+	}
+}
+
+func TestYamlQuoteIfNeeded(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://example.com", "https://example.com"},
+		{"simple text", "simple text"},
+		{"has: colon space", `"has: colon space"`},
+		{"has #comment", `"has #comment"`},
+		{"*star", `"*star"`},
+		{"", "''"},
+	}
+
+	for _, tc := range tests {
+		result := yamlQuoteIfNeeded(tc.input)
+		if result != tc.expected {
+			t.Errorf("yamlQuoteIfNeeded(%q) = %q, want %q", tc.input, result, tc.expected)
+		}
 	}
 }


### PR DESCRIPTION
The landscape-updater was rewriting the entire `landscape.yml` file wihtout compare what changed, which caused to add changes like trailing whitespaces, re-formating fields, collapsing multi-line fields, etc. I attached examples in #407 

I introduced line-level edits to the `landscape.yml` instead of rewriting full file. 
It tracks if the changes are new values, extra fields, or already exist and updates the file accordingly.

