### PR TITLE
fix: lower Go version requirement from 1.26.1 to 1.22

### DIFF
--- a/utilities/dot-project/Dockerfile
+++ b/utilities/dot-project/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 RUN apk add --no-cache git
 

--- a/utilities/dot-project/go.mod
+++ b/utilities/dot-project/go.mod
@@ -1,5 +1,5 @@
 module projects
 
-go 1.26.1
+go 1.22
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
Restore backward compatibility with downstream consumers running older Go versions (e.g., Go 1.24.13 with GOTOOLCHAIN=local).

The code does not use any Go 1.23+ or 1.26+ language features and the only dependency (gopkg.in/yaml.v3 v3.0.1) supports Go 1.22.

This reverts the Go version to 1.22 (the previous requirement before commit 825db5c) to ensure the validate-project and validate-maintainers actions work with GitHub-hosted runners using older Go toolchains.

Fixes: #426 Encountered on CoHDI/.project workflow validation checks
Related: https://github.com/CoHDI/.project/actions/runs/26087586615/job/76710626384