### PR TITLE
fix(labeler): honor matchCondition: AND and support brace patterns (my pick — matches the commit, scoped, descriptive)

### DIFF
--- a/utilities/labeler/labeler.go
+++ b/utilities/labeler/labeler.go
@@ -213,6 +213,17 @@ func (l *Labeler) processMatchRule(ctx context.Context, req *LabelRequest, rule 
 }
 
 func (l *Labeler) processLabelRule(ctx context.Context, req *LabelRequest, rule Rule) error {
+	// Compile and validate the rule's match pattern once, before iterating
+	// existing labels. Doing this only inside the loop would skip validation
+	// on issues that have zero labels yet (e.g. a freshly-opened PR), which
+	// would let a malformed pattern silently fall through to
+	// foundNamespace=false and fire the rule in the wrong direction.
+	patterns, err := compilePatterns(rule.Spec.Match)
+	if err != nil {
+		return fmt.Errorf("rule %q: invalid match pattern %q: %v",
+			rule.Name, rule.Spec.Match, err)
+	}
+
 	existingLabels, _, err := l.client.ListLabelsByIssue(ctx, req.Owner, req.Repo, req.IssueNumber, nil)
 	if err != nil {
 		return fmt.Errorf("failed to fetch labels for issue: %v", err)
@@ -220,12 +231,7 @@ func (l *Labeler) processLabelRule(ctx context.Context, req *LabelRequest, rule 
 
 	foundNamespace := false
 	for _, lbl := range existingLabels {
-		matched, err := matchAnyPattern(rule.Spec.Match, lbl.GetName())
-		if err != nil {
-			return fmt.Errorf("rule %q: invalid match pattern %q: %v",
-				rule.Name, rule.Spec.Match, err)
-		}
-		if matched {
+		if matchAny(patterns, lbl.GetName()) {
 			foundNamespace = true
 			break
 		}
@@ -287,38 +293,46 @@ func (l *Labeler) executeAction(ctx context.Context, req *LabelRequest, action A
 	return nil
 }
 
-// matchAnyPattern reports whether name matches pattern, with support for a
-// single level of comma-separated brace alternation in addition to the
-// wildcards understood by path.Match.
+// compilePatterns expands and validates a rule's match pattern, returning
+// the slice of concrete path.Match patterns that should be tried for each
+// label. Supports a single level of comma-separated brace alternation
+// (e.g. "{toc,tag/*,sub/*}") in addition to the wildcards understood by
+// path.Match.
 //
-// Examples:
-//
-//	matchAnyPattern("triage/*", "triage/valid")           → true
-//	matchAnyPattern("{toc,tag/*,sub/*}", "tag/infra")     → true
-//	matchAnyPattern("{toc,tag/*,sub/*}", "needs-triage")  → false
-//
-// path.Match alone does not understand brace alternation, so without this
-// helper a pattern like "{toc,tag/*,sub/*}" only matches a literal label
-// whose name begins with "{".
+// Validation happens here rather than at match time so callers can surface
+// a malformed pattern even on issues that have no labels yet — otherwise
+// the match loop would never execute and the rule would silently fire
+// based on foundNamespace=false.
 //
 // path.Match (not filepath.Match) is used so that "/" is always treated as
-// the separator regardless of the host OS — labels are not filesystem paths
-// and "*" must not cross "/" on any platform.
-func matchAnyPattern(pattern, name string) (bool, error) {
+// the separator regardless of the host OS — labels are not filesystem
+// paths and "*" must not cross "/" on any platform.
+func compilePatterns(pattern string) ([]string, error) {
 	patterns, err := expandBraces(pattern)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
+	// path.Match reports ErrBadPattern on malformed inputs (unclosed
+	// character classes, etc.) regardless of the name argument, so a
+	// single call per expanded pattern is enough to validate it.
 	for _, p := range patterns {
-		matched, err := path.Match(p, name)
-		if err != nil {
-			return false, err
-		}
-		if matched {
-			return true, nil
+		if _, err := path.Match(p, ""); err != nil {
+			return nil, fmt.Errorf("malformed pattern %q: %v", p, err)
 		}
 	}
-	return false, nil
+	return patterns, nil
+}
+
+// matchAny reports whether name matches any of the pre-compiled patterns.
+// The patterns must already have been validated by compilePatterns; any
+// path.Match error is therefore unexpected and treated as "no match".
+func matchAny(patterns []string, name string) bool {
+	for _, p := range patterns {
+		if matched, _ := path.Match(p, name); matched {
+			return true
+		}
+	}
+	return false
 }
 
 // expandBraces expands a single, non-nested brace alternation in pattern.

--- a/utilities/labeler/labeler.go
+++ b/utilities/labeler/labeler.go
@@ -219,19 +219,30 @@ func (l *Labeler) processLabelRule(ctx context.Context, req *LabelRequest, rule 
 
 	foundNamespace := false
 	for _, lbl := range existingLabels {
-		matched, _ := filepath.Match(rule.Spec.Match, lbl.GetName())
+		matched, _ := matchAnyPattern(rule.Spec.Match, lbl.GetName())
 		if matched {
 			foundNamespace = true
 			break
 		}
 	}
 
-	// Default logic: apply if the namespace is NOT found
-	// For "NOT" condition: apply if the namespace is NOT found (same as default)
+	// Decide whether to fire the rule's actions based on matchCondition:
+	//   "AND" → fire when the namespace IS present on the issue.
+	//   "NOT" (or unset, the default) → fire when the namespace is NOT present.
+	// Without honoring "AND" here, a rule like
+	//     match: triage/*
+	//     matchCondition: AND
+	//     actions: [remove-label: needs-triage]
+	// behaves identically to its "NOT" sibling and ends up firing in exactly
+	// the wrong situations (e.g. removing needs-triage when no triage/* is set
+	// while a fresh PR is being opened, and never removing it once one is).
 	shouldApply := !foundNamespace
+	if strings.EqualFold(rule.Spec.MatchCondition, "AND") {
+		shouldApply = foundNamespace
+	}
 
 	if l.config.Debug {
-		log.Printf("Label rule %s: foundNamespace=%v, matchCondition=%s, shouldApply=%v", 
+		log.Printf("Label rule %s: foundNamespace=%v, matchCondition=%s, shouldApply=%v",
 			rule.Name, foundNamespace, rule.Spec.MatchCondition, shouldApply)
 	}
 
@@ -269,6 +280,51 @@ func (l *Labeler) executeAction(ctx context.Context, req *LabelRequest, action A
 		}
 	}
 	return nil
+}
+
+// matchAnyPattern reports whether name matches pattern, with support for a
+// single level of comma-separated brace alternation in addition to the
+// wildcards understood by filepath.Match.
+//
+// Examples:
+//
+//	matchAnyPattern("triage/*", "triage/valid")           → true
+//	matchAnyPattern("{toc,tag/*,sub/*}", "tag/infra")     → true
+//	matchAnyPattern("{toc,tag/*,sub/*}", "needs-triage")  → false
+//
+// filepath.Match itself does not understand brace alternation, so without
+// this helper a pattern like "{toc,tag/*,sub/*}" only matches a literal
+// label whose name begins with "{".
+func matchAnyPattern(pattern, name string) (bool, error) {
+	for _, p := range expandBraces(pattern) {
+		matched, err := filepath.Match(p, name)
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// expandBraces expands a single, non-nested brace alternation in pattern.
+// "{a,b/*,c}" → ["a", "b/*", "c"], "foo-{a,b}" → ["foo-a", "foo-b"].
+// Patterns without braces are returned unchanged as a single-element slice.
+func expandBraces(pattern string) []string {
+	start := strings.Index(pattern, "{")
+	end := strings.Index(pattern, "}")
+	if start == -1 || end == -1 || end < start {
+		return []string{pattern}
+	}
+	prefix := pattern[:start]
+	suffix := pattern[end+1:]
+	parts := strings.Split(pattern[start+1:end], ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, prefix+strings.TrimSpace(p)+suffix)
+	}
+	return out
 }
 
 func (l *Labeler) renderLabel(template string, argv []string) string {

--- a/utilities/labeler/labeler.go
+++ b/utilities/labeler/labeler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -288,7 +289,7 @@ func (l *Labeler) executeAction(ctx context.Context, req *LabelRequest, action A
 
 // matchAnyPattern reports whether name matches pattern, with support for a
 // single level of comma-separated brace alternation in addition to the
-// wildcards understood by filepath.Match.
+// wildcards understood by path.Match.
 //
 // Examples:
 //
@@ -296,12 +297,20 @@ func (l *Labeler) executeAction(ctx context.Context, req *LabelRequest, action A
 //	matchAnyPattern("{toc,tag/*,sub/*}", "tag/infra")     → true
 //	matchAnyPattern("{toc,tag/*,sub/*}", "needs-triage")  → false
 //
-// filepath.Match itself does not understand brace alternation, so without
-// this helper a pattern like "{toc,tag/*,sub/*}" only matches a literal
-// label whose name begins with "{".
+// path.Match alone does not understand brace alternation, so without this
+// helper a pattern like "{toc,tag/*,sub/*}" only matches a literal label
+// whose name begins with "{".
+//
+// path.Match (not filepath.Match) is used so that "/" is always treated as
+// the separator regardless of the host OS — labels are not filesystem paths
+// and "*" must not cross "/" on any platform.
 func matchAnyPattern(pattern, name string) (bool, error) {
-	for _, p := range expandBraces(pattern) {
-		matched, err := filepath.Match(p, name)
+	patterns, err := expandBraces(pattern)
+	if err != nil {
+		return false, err
+	}
+	for _, p := range patterns {
+		matched, err := path.Match(p, name)
 		if err != nil {
 			return false, err
 		}
@@ -315,20 +324,39 @@ func matchAnyPattern(pattern, name string) (bool, error) {
 // expandBraces expands a single, non-nested brace alternation in pattern.
 // "{a,b/*,c}" → ["a", "b/*", "c"], "foo-{a,b}" → ["foo-a", "foo-b"].
 // Patterns without braces are returned unchanged as a single-element slice.
-func expandBraces(pattern string) []string {
+//
+// Multiple brace pairs (e.g. "foo-{a,b}-{c,d}") and nested braces
+// (e.g. "{a,{b,c}}") are not supported and produce an error rather than a
+// partial expansion that would silently mis-match (e.g. "foo-{a,b}-{c,d}"
+// would expand to "foo-a-{c,d}" / "foo-b-{c,d}", and path.Match would then
+// treat "{c,d}" as literal characters).
+//
+// A mismatched '}' before any '{' is treated the same way — better to
+// surface the malformed pattern than to silently match unexpectedly.
+func expandBraces(pattern string) ([]string, error) {
 	start := strings.Index(pattern, "{")
 	end := strings.Index(pattern, "}")
-	if start == -1 || end == -1 || end < start {
-		return []string{pattern}
+	if start == -1 && end == -1 {
+		return []string{pattern}, nil
+	}
+	if start == -1 || end < start {
+		return nil, fmt.Errorf("unbalanced braces in pattern %q", pattern)
+	}
+	inner := pattern[start+1 : end]
+	suffix := pattern[end+1:]
+	if strings.ContainsAny(inner, "{}") || strings.ContainsAny(suffix, "{}") {
+		return nil, fmt.Errorf(
+			"pattern %q has nested or multiple brace groups; only a single, non-nested {a,b,c} is supported",
+			pattern,
+		)
 	}
 	prefix := pattern[:start]
-	suffix := pattern[end+1:]
-	parts := strings.Split(pattern[start+1:end], ",")
+	parts := strings.Split(inner, ",")
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {
 		out = append(out, prefix+strings.TrimSpace(p)+suffix)
 	}
-	return out
+	return out, nil
 }
 
 func (l *Labeler) renderLabel(template string, argv []string) string {

--- a/utilities/labeler/labeler.go
+++ b/utilities/labeler/labeler.go
@@ -219,7 +219,11 @@ func (l *Labeler) processLabelRule(ctx context.Context, req *LabelRequest, rule 
 
 	foundNamespace := false
 	for _, lbl := range existingLabels {
-		matched, _ := matchAnyPattern(rule.Spec.Match, lbl.GetName())
+		matched, err := matchAnyPattern(rule.Spec.Match, lbl.GetName())
+		if err != nil {
+			return fmt.Errorf("rule %q: invalid match pattern %q: %v",
+				rule.Name, rule.Spec.Match, err)
+		}
 		if matched {
 			foundNamespace = true
 			break

--- a/utilities/labeler/labeler_test.go
+++ b/utilities/labeler/labeler_test.go
@@ -553,8 +553,13 @@ func TestLabeler_ProcessLabelRule_BracePattern(t *testing.T) {
 // TestLabeler_ProcessLabelRule_InvalidPattern verifies that a malformed
 // `match` pattern surfaces as an error instead of silently leaving
 // foundNamespace=false and causing the rule to fire in the wrong direction.
-// `[` opens a character class that is never closed, so filepath.Match
-// returns ErrBadPattern.
+// `[` opens a character class that is never closed, so path.Match returns
+// ErrBadPattern.
+//
+// Critically, the existing-labels slice here is empty: an earlier version
+// of the code validated patterns only inside the existing-labels loop,
+// which meant a freshly-opened issue with zero labels never validated and
+// would silently apply the malformed rule.
 func TestLabeler_ProcessLabelRule_InvalidPattern(t *testing.T) {
 	cfg := &LabelsYAML{
 		AutoCreate:         true,
@@ -577,7 +582,7 @@ func TestLabeler_ProcessLabelRule_InvalidPattern(t *testing.T) {
 
 	client := NewMockGitHubClient()
 	labeler := NewLabeler(client, cfg)
-	client.IssueLabels[1] = []*github.Label{{Name: stringPtr("some-label")}}
+	client.IssueLabels[1] = []*github.Label{} // intentionally empty: zero-label case
 
 	// processRules swallows per-rule errors (it only logs them), so calling
 	// processLabelRule directly is the cleanest way to assert on the error.
@@ -659,7 +664,7 @@ func TestLabeler_ProcessLabelRule_UnsupportedBracePattern(t *testing.T) {
 
 	client := NewMockGitHubClient()
 	labeler := NewLabeler(client, cfg)
-	client.IssueLabels[1] = []*github.Label{{Name: stringPtr("some-label")}}
+	client.IssueLabels[1] = []*github.Label{} // zero-label case: validation must still trigger
 
 	err := labeler.processLabelRule(context.Background(), &LabelRequest{
 		Owner: "o", Repo: "r", IssueNumber: 1,

--- a/utilities/labeler/labeler_test.go
+++ b/utilities/labeler/labeler_test.go
@@ -597,19 +597,81 @@ func TestLabeler_ProcessLabelRule_InvalidPattern(t *testing.T) {
 
 func TestExpandBraces(t *testing.T) {
 	cases := []struct {
-		in   string
-		want []string
+		name    string
+		in      string
+		want    []string
+		wantErr bool
 	}{
-		{"triage/*", []string{"triage/*"}},
-		{"{toc,tag/*,sub/*}", []string{"toc", "tag/*", "sub/*"}},
-		{"foo-{a,b}", []string{"foo-a", "foo-b"}},
-		{"{a, b ,c}", []string{"a", "b", "c"}}, // surrounding whitespace trimmed
+		{name: "no braces", in: "triage/*", want: []string{"triage/*"}},
+		{name: "leading brace group", in: "{toc,tag/*,sub/*}", want: []string{"toc", "tag/*", "sub/*"}},
+		{name: "prefix only", in: "foo-{a,b}", want: []string{"foo-a", "foo-b"}},
+		{name: "whitespace trimmed", in: "{a, b ,c}", want: []string{"a", "b", "c"}},
+
+		// Unsupported patterns: better to surface an error than to silently
+		// produce partial expansions that match unexpectedly.
+		{name: "multiple brace groups", in: "foo-{a,b}-{c,d}", wantErr: true},
+		{name: "nested braces", in: "{a,{b,c}}", wantErr: true},
+		{name: "unbalanced (no close)", in: "foo-{a,b", wantErr: true},
+		{name: "unbalanced (close before open)", in: "foo}-{a,b}", wantErr: true},
 	}
 	for _, tc := range cases {
-		got := expandBraces(tc.in)
-		if !slicesEqual(got, tc.want) {
-			t.Errorf("expandBraces(%q) = %v, want %v", tc.in, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandBraces(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expandBraces(%q): expected error, got %v", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expandBraces(%q): unexpected error: %v", tc.in, err)
+			}
+			if !slicesEqual(got, tc.want) {
+				t.Errorf("expandBraces(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLabeler_ProcessLabelRule_UnsupportedBracePattern verifies that an
+// unsupported brace pattern (multiple groups, nested groups, or unbalanced
+// braces) causes processLabelRule to return an error naming the rule and
+// the pattern, rather than silently mis-matching via a partial expansion.
+func TestLabeler_ProcessLabelRule_UnsupportedBracePattern(t *testing.T) {
+	cfg := &LabelsYAML{
+		AutoCreate:         true,
+		AutoDelete:         false,
+		DefinitionRequired: true,
+		Labels: []Label{
+			{Name: "needs-group", Color: "FBCA04", Description: "Needs a group label"},
+		},
+		Ruleset: []Rule{
+			{
+				Name: "bad-brace-pattern",
+				Kind: "label",
+				Spec: RuleSpec{Match: "foo-{a,b}-{c,d}", MatchCondition: "NOT"},
+				Actions: []Action{
+					{Kind: "apply-label", Spec: ActionSpec{Label: "needs-group"}},
+				},
+			},
+		},
+	}
+
+	client := NewMockGitHubClient()
+	labeler := NewLabeler(client, cfg)
+	client.IssueLabels[1] = []*github.Label{{Name: stringPtr("some-label")}}
+
+	err := labeler.processLabelRule(context.Background(), &LabelRequest{
+		Owner: "o", Repo: "r", IssueNumber: 1,
+	}, cfg.Ruleset[0])
+	if err == nil {
+		t.Fatalf("expected an error for unsupported brace pattern, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad-brace-pattern") || !strings.Contains(err.Error(), "foo-{a,b}-{c,d}") {
+		t.Errorf("error should mention rule name and bad pattern; got: %v", err)
+	}
+	if sliceContains(client.AppliedLabels[1], "needs-group") {
+		t.Errorf("rule with unsupported pattern must not apply labels; applied=%v", client.AppliedLabels[1])
 	}
 }
 

--- a/utilities/labeler/labeler_test.go
+++ b/utilities/labeler/labeler_test.go
@@ -375,6 +375,199 @@ func TestLabeler_ProcessLabelRule_HasTriageLabel(t *testing.T) {
 	}
 }
 
+// TestLabeler_ProcessLabelRule_RemoveWithMatchConditionAND exercises the
+// regression where a label rule with `matchCondition: AND` was treated like
+// `NOT` and fired in exactly the wrong situations. See cncf/toc#2164 for the
+// user-visible symptom: a freshly-opened PR would have `needs-triage`,
+// `needs-kind`, and `needs-group` added and immediately removed in the same
+// workflow run, and a manually-applied `triage/*`/`kind/*`/group label would
+// never auto-clear its paired `needs-*` label.
+func TestLabeler_ProcessLabelRule_RemoveWithMatchConditionAND(t *testing.T) {
+	// Minimal config that pairs a NOT rule (apply needs-triage when no
+	// triage/* exists) with an AND rule (remove needs-triage when one does).
+	cfg := &LabelsYAML{
+		AutoCreate:         true,
+		AutoDelete:         false,
+		DefinitionRequired: true,
+		Labels: []Label{
+			{Name: "needs-triage", Color: "ededed", Description: "Needs triage"},
+			{Name: "triage/valid", Color: "0e8a16", Description: "Valid issue"},
+		},
+		Ruleset: []Rule{
+			{
+				Name: "needs-triage",
+				Kind: "label",
+				Spec: RuleSpec{Match: "triage/*", MatchCondition: "NOT"},
+				Actions: []Action{
+					{Kind: "apply-label", Spec: ActionSpec{Label: "needs-triage"}},
+				},
+			},
+			{
+				Name: "remove-needs-triage",
+				Kind: "label",
+				Spec: RuleSpec{Match: "triage/*", MatchCondition: "AND"},
+				Actions: []Action{
+					{Kind: "remove-label", Spec: ActionSpec{Match: "needs-triage"}},
+				},
+			},
+		},
+	}
+
+	t.Run("no triage/* present: only NOT rule fires", func(t *testing.T) {
+		client := NewMockGitHubClient()
+		labeler := NewLabeler(client, cfg)
+		client.IssueLabels[1] = []*github.Label{}
+
+		err := labeler.ProcessRequest(context.Background(), &LabelRequest{
+			Owner: "o", Repo: "r", IssueNumber: 1,
+		})
+		if err != nil {
+			t.Fatalf("ProcessRequest failed: %v", err)
+		}
+
+		if !sliceContains(client.AppliedLabels[1], "needs-triage") {
+			t.Errorf("expected needs-triage to be applied, got applied=%v", client.AppliedLabels[1])
+		}
+		if sliceContains(client.RemovedLabels[1], "needs-triage") {
+			t.Errorf("AND rule must not fire when no triage/* is present; removed=%v", client.RemovedLabels[1])
+		}
+	})
+
+	t.Run("triage/* present: only AND rule fires", func(t *testing.T) {
+		client := NewMockGitHubClient()
+		labeler := NewLabeler(client, cfg)
+		client.IssueLabels[2] = []*github.Label{
+			{Name: stringPtr("needs-triage")},
+			{Name: stringPtr("triage/valid")},
+		}
+
+		err := labeler.ProcessRequest(context.Background(), &LabelRequest{
+			Owner: "o", Repo: "r", IssueNumber: 2,
+		})
+		if err != nil {
+			t.Fatalf("ProcessRequest failed: %v", err)
+		}
+
+		if sliceContains(client.AppliedLabels[2], "needs-triage") {
+			t.Errorf("NOT rule must not fire when triage/* is present; applied=%v", client.AppliedLabels[2])
+		}
+		if !sliceContains(client.RemovedLabels[2], "needs-triage") {
+			t.Errorf("expected AND rule to remove needs-triage, got removed=%v", client.RemovedLabels[2])
+		}
+	})
+}
+
+// TestLabeler_ProcessLabelRule_BracePattern verifies that label-rule
+// `match` values can use brace alternation like `{toc,tag/*,sub/*}`.
+// filepath.Match alone does not understand braces, so before this fix a
+// pattern with braces only matched a literal label starting with "{".
+func TestLabeler_ProcessLabelRule_BracePattern(t *testing.T) {
+	cfg := &LabelsYAML{
+		AutoCreate:         true,
+		AutoDelete:         false,
+		DefinitionRequired: true,
+		Labels: []Label{
+			{Name: "needs-group", Color: "FBCA04", Description: "Needs a group label"},
+			{Name: "toc", Color: "C13B8A", Description: "TOC specific issue"},
+			{Name: "tag/infrastructure", Color: "0E8A8A", Description: "TAG Infrastructure"},
+			{Name: "sub/mentoring", Color: "1D76DB", Description: "TOC Mentoring Subproject"},
+		},
+		Ruleset: []Rule{
+			{
+				Name: "needs-group",
+				Kind: "label",
+				Spec: RuleSpec{Match: "{toc,tag/*,sub/*}", MatchCondition: "NOT"},
+				Actions: []Action{
+					{Kind: "apply-label", Spec: ActionSpec{Label: "needs-group"}},
+				},
+			},
+			{
+				Name: "remove-needs-group",
+				Kind: "label",
+				Spec: RuleSpec{Match: "{toc,tag/*,sub/*}", MatchCondition: "AND"},
+				Actions: []Action{
+					{Kind: "remove-label", Spec: ActionSpec{Match: "needs-group"}},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		existing    []*github.Label
+		wantApply   bool
+		wantRemove  bool
+	}{
+		{
+			name:       "no group label → needs-group applied",
+			existing:   []*github.Label{},
+			wantApply:  true,
+			wantRemove: false,
+		},
+		{
+			name:       "toc present → needs-group removed",
+			existing:   []*github.Label{{Name: stringPtr("needs-group")}, {Name: stringPtr("toc")}},
+			wantApply:  false,
+			wantRemove: true,
+		},
+		{
+			name:       "tag/* present → needs-group removed",
+			existing:   []*github.Label{{Name: stringPtr("needs-group")}, {Name: stringPtr("tag/infrastructure")}},
+			wantApply:  false,
+			wantRemove: true,
+		},
+		{
+			name:       "sub/* present → needs-group removed",
+			existing:   []*github.Label{{Name: stringPtr("needs-group")}, {Name: stringPtr("sub/mentoring")}},
+			wantApply:  false,
+			wantRemove: true,
+		},
+	}
+
+	for i, tc := range cases {
+		issueNum := i + 1
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewMockGitHubClient()
+			labeler := NewLabeler(client, cfg)
+			client.IssueLabels[issueNum] = tc.existing
+
+			err := labeler.ProcessRequest(context.Background(), &LabelRequest{
+				Owner: "o", Repo: "r", IssueNumber: issueNum,
+			})
+			if err != nil {
+				t.Fatalf("ProcessRequest failed: %v", err)
+			}
+
+			gotApply := sliceContains(client.AppliedLabels[issueNum], "needs-group")
+			gotRemove := sliceContains(client.RemovedLabels[issueNum], "needs-group")
+			if gotApply != tc.wantApply {
+				t.Errorf("apply needs-group: got %v want %v (applied=%v)", gotApply, tc.wantApply, client.AppliedLabels[issueNum])
+			}
+			if gotRemove != tc.wantRemove {
+				t.Errorf("remove needs-group: got %v want %v (removed=%v)", gotRemove, tc.wantRemove, client.RemovedLabels[issueNum])
+			}
+		})
+	}
+}
+
+func TestExpandBraces(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"triage/*", []string{"triage/*"}},
+		{"{toc,tag/*,sub/*}", []string{"toc", "tag/*", "sub/*"}},
+		{"foo-{a,b}", []string{"foo-a", "foo-b"}},
+		{"{a, b ,c}", []string{"a", "b", "c"}}, // surrounding whitespace trimmed
+	}
+	for _, tc := range cases {
+		got := expandBraces(tc.in)
+		if !slicesEqual(got, tc.want) {
+			t.Errorf("expandBraces(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestLabeler_ProcessMatchRule_InvalidArgument(t *testing.T) {
 	client := NewMockGitHubClient()
 	config := createTestConfig()

--- a/utilities/labeler/labeler_test.go
+++ b/utilities/labeler/labeler_test.go
@@ -550,6 +550,51 @@ func TestLabeler_ProcessLabelRule_BracePattern(t *testing.T) {
 	}
 }
 
+// TestLabeler_ProcessLabelRule_InvalidPattern verifies that a malformed
+// `match` pattern surfaces as an error instead of silently leaving
+// foundNamespace=false and causing the rule to fire in the wrong direction.
+// `[` opens a character class that is never closed, so filepath.Match
+// returns ErrBadPattern.
+func TestLabeler_ProcessLabelRule_InvalidPattern(t *testing.T) {
+	cfg := &LabelsYAML{
+		AutoCreate:         true,
+		AutoDelete:         false,
+		DefinitionRequired: true,
+		Labels: []Label{
+			{Name: "needs-triage", Color: "ededed", Description: "Needs triage"},
+		},
+		Ruleset: []Rule{
+			{
+				Name: "bad-pattern",
+				Kind: "label",
+				Spec: RuleSpec{Match: "triage/[", MatchCondition: "NOT"},
+				Actions: []Action{
+					{Kind: "apply-label", Spec: ActionSpec{Label: "needs-triage"}},
+				},
+			},
+		},
+	}
+
+	client := NewMockGitHubClient()
+	labeler := NewLabeler(client, cfg)
+	client.IssueLabels[1] = []*github.Label{{Name: stringPtr("some-label")}}
+
+	// processRules swallows per-rule errors (it only logs them), so calling
+	// processLabelRule directly is the cleanest way to assert on the error.
+	err := labeler.processLabelRule(context.Background(), &LabelRequest{
+		Owner: "o", Repo: "r", IssueNumber: 1,
+	}, cfg.Ruleset[0])
+	if err == nil {
+		t.Fatalf("expected an error for invalid match pattern, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad-pattern") || !strings.Contains(err.Error(), "triage/[") {
+		t.Errorf("error should mention rule name and bad pattern; got: %v", err)
+	}
+	if sliceContains(client.AppliedLabels[1], "needs-triage") {
+		t.Errorf("rule with invalid pattern must not apply labels; applied=%v", client.AppliedLabels[1])
+	}
+}
+
 func TestExpandBraces(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
## Summary

Fixes two bugs in `utilities/labeler` that together cause the symptom on [cncf/toc#2164](https://github.com/cncf/toc/pull/2164): the bot adds `needs-triage` / `needs-kind` / `needs-group` to a fresh PR and immediately removes them in the same run.

1. **`matchCondition: AND` was ignored.** `processLabelRule` always computed `shouldApply := !foundNamespace`, so an `AND` rule behaved identically to its paired `NOT` rule — exactly inverted from intent. On a fresh PR, both rules fired: one added `needs-*`, the other removed it. Conversely, when a `triage/*` label was added via the UI, the `AND` rule never fired, so `needs-triage` never auto-cleared.

2. **Brace patterns like `{toc,tag/*,sub/*}` never matched.** `filepath.Match` doesn't understand brace alternation, so the cncf/toc `needs-group` rule's pattern only matched a literal label starting with `{`. Hidden today by bug #1; would surface as `needs-group` getting permanently applied if #1 were fixed alone.

## Fix

- Honor `matchCondition: AND` in `processLabelRule`.
- Add a small `matchAnyPattern` / `expandBraces` helper so `{a,b/*,c}`-style patterns work.

## Tests

- `TestLabeler_ProcessLabelRule_RemoveWithMatchConditionAND` — regression for the cncf/toc#2164 scenario.
- `TestLabeler_ProcessLabelRule_BracePattern` — table test across each brace alternative.
- `TestExpandBraces` — unit test for the expander.

`go vet` and `go test ./utilities/labeler/...` both pass.