### PR TITLE
feat: support multiple project_lead and package_managers values

### DIFF
--- a/utilities/dot-project/SCHEMA.md
+++ b/utilities/dot-project/SCHEMA.md
@@ -16,8 +16,8 @@ This document defines the schema for CNCF `.project` repository metadata files.
 | `name` | string | Yes | Project display name | Non-empty |
 | `description` | string | Yes | One-line project description | Non-empty |
 | `type` | string | No | Project type | Free text (e.g., `"project"`, `"platform"`, `"specification"`) |
-| `package_managers` | map[string]string | No | Registry identifiers (e.g., npm, Docker Hub) | All values must be non-empty strings |
-| `project_lead` | string | No | Primary contact GitHub handle or team | Non-empty if present; `@` prefix is stripped; can be a GitHub handle (e.g., `jdoe`) or a GitHub team (e.g., `org/team-name`) |
+| `package_managers` | map[string](string\|string[]) | No | Registry identifiers. Each value is a single string or a list of strings (e.g., multiple Docker images) | All values must be non-empty strings |
+| `project_lead` | string \| string[] | No | One or more primary contact GitHub handles or teams. Accepts a plain string (single lead, backward-compatible) or a YAML list (multiple leads) | Non-empty if present; `@` prefix is stripped; each entry can be a GitHub handle (e.g., `jdoe`) or a GitHub team (e.g., `org/team-name`) |
 | `slack_channels` | SlackChannel[] | No | One or more CNCF Slack channels | Each `name` must start with `#`; at most one entry may set `primary: true` |
 | `maturity_log` | MaturityEntry[] | Yes | Maturity phase history | At least one entry; chronological order |
 | `repositories` | string[] | Yes | Repository URLs | At least one valid HTTP(S) URL |

--- a/utilities/dot-project/cmd/generate-schema/main.go
+++ b/utilities/dot-project/cmd/generate-schema/main.go
@@ -30,6 +30,7 @@ type JSONSchemaProperty struct {
 	Required             []string                      `json:"required,omitempty"`
 	Ref                  string                        `json:"$ref,omitempty"`
 	AdditionalProperties interface{}                   `json:"additionalProperties,omitempty"`
+	OneOf                []JSONSchemaProperty          `json:"oneOf,omitempty"`
 }
 
 func main() {
@@ -44,12 +45,18 @@ func main() {
 		AdditionalProperties: &falseVal,
 		Required:             []string{"schema_version", "slug", "name", "description", "maturity_log", "repositories"},
 		Properties: map[string]JSONSchemaProperty{
-			"schema_version":     {Type: "string", Description: "Schema version", Enum: []string{"1.0.0"}},
-			"slug":               {Type: "string", Description: "Unique project identifier", Pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$"},
-			"name":               {Type: "string", Description: "Project display name"},
-			"description":        {Type: "string", Description: "One-line project description"},
-			"type":               {Type: "string", Description: "Project type (e.g., project, platform, specification)"},
-			"project_lead": {Type: "string", Description: "GitHub handle or team (org/team-name) of primary contact"},
+			"schema_version": {Type: "string", Description: "Schema version", Enum: []string{"1.0.0"}},
+			"slug":           {Type: "string", Description: "Unique project identifier", Pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$"},
+			"name":           {Type: "string", Description: "Project display name"},
+			"description":    {Type: "string", Description: "One-line project description"},
+			"type":           {Type: "string", Description: "Project type (e.g., project, platform, specification)"},
+			"project_lead": {
+				Description: "One or more GitHub handles or team references (org/team-name) for the project lead(s). Accepts a plain string (single lead) or a list (multiple leads).",
+				OneOf: []JSONSchemaProperty{
+					{Type: "string"},
+					{Type: "array", Items: &JSONSchemaProperty{Type: "string"}},
+				},
+			},
 			"slack_channels": {
 				Type:        "array",
 				Description: "CNCF Slack channels (one or more). Mark the channel most end-users should join with primary: true.",
@@ -65,18 +72,27 @@ func main() {
 				Description: "Repository URLs",
 				Items:       &JSONSchemaProperty{Type: "string", Format: "uri"},
 			},
-			"website":          {Type: "string", Description: "Project website URL", Format: "uri"},
-			"artwork":          {Type: "string", Description: "Artwork/logo URL", Format: "uri"},
-			"social":           {Type: "object", Description: "Social platform URLs", AdditionalProperties: JSONSchemaProperty{Type: "string", Format: "uri"}},
-			"mailing_lists":    {Type: "array", Description: "Mailing list addresses", Items: &JSONSchemaProperty{Type: "string"}},
-			"audits":           {Type: "array", Description: "Security/performance audits", Items: &JSONSchemaProperty{Ref: "#/$defs/Audit"}},
-			"adopters":         {Ref: "#/$defs/PathRef", Description: "Link to ADOPTERS.md or adopters list"},
-			"package_managers": {Type: "object", Description: "Registry identifiers (e.g., npm package name, Docker Hub image)", AdditionalProperties: JSONSchemaProperty{Type: "string"}},
-			"security":         {Ref: "#/$defs/SecurityConfig", Description: "Security configuration"},
-			"governance":       {Ref: "#/$defs/GovernanceConfig", Description: "Governance configuration"},
-			"legal":            {Ref: "#/$defs/LegalConfig", Description: "Legal configuration"},
-			"documentation":    {Ref: "#/$defs/DocumentationConfig", Description: "Documentation configuration"},
-			"landscape":        {Ref: "#/$defs/LandscapeConfig", Description: "CNCF Landscape location"},
+			"website":       {Type: "string", Description: "Project website URL", Format: "uri"},
+			"artwork":       {Type: "string", Description: "Artwork/logo URL", Format: "uri"},
+			"social":        {Type: "object", Description: "Social platform URLs", AdditionalProperties: JSONSchemaProperty{Type: "string", Format: "uri"}},
+			"mailing_lists": {Type: "array", Description: "Mailing list addresses", Items: &JSONSchemaProperty{Type: "string"}},
+			"audits":        {Type: "array", Description: "Security/performance audits", Items: &JSONSchemaProperty{Ref: "#/$defs/Audit"}},
+			"adopters":      {Ref: "#/$defs/PathRef", Description: "Link to ADOPTERS.md or adopters list"},
+			"package_managers": {
+				Type:        "object",
+				Description: "Registry identifiers. Each key is a registry name (e.g., docker, npm, fedora). Each value is a single identifier string or a list of identifiers (e.g., multiple Docker images).",
+				AdditionalProperties: JSONSchemaProperty{
+					OneOf: []JSONSchemaProperty{
+						{Type: "string"},
+						{Type: "array", Items: &JSONSchemaProperty{Type: "string"}},
+					},
+				},
+			},
+			"security":      {Ref: "#/$defs/SecurityConfig", Description: "Security configuration"},
+			"governance":    {Ref: "#/$defs/GovernanceConfig", Description: "Governance configuration"},
+			"legal":         {Ref: "#/$defs/LegalConfig", Description: "Legal configuration"},
+			"documentation": {Ref: "#/$defs/DocumentationConfig", Description: "Documentation configuration"},
+			"landscape":     {Ref: "#/$defs/LandscapeConfig", Description: "CNCF Landscape location"},
 		},
 		Defs: map[string]JSONSchema{
 			"MaturityEntry": {

--- a/utilities/dot-project/cmd/migrate/main.go
+++ b/utilities/dot-project/cmd/migrate/main.go
@@ -91,7 +91,7 @@ func main() {
 		project.Website = *website
 	}
 	if *projectLead != "" {
-		project.ProjectLead = strings.TrimPrefix(*projectLead, "@")
+		project.ProjectLeads = projects.StringOrSlice{strings.TrimPrefix(*projectLead, "@")}
 	}
 	if *slackChannel != "" {
 		project.SlackChannels = []projects.SlackChannel{

--- a/utilities/dot-project/example/project.yaml
+++ b/utilities/dot-project/example/project.yaml
@@ -9,7 +9,9 @@ slug: "kubernetes"
 name: "Kubernetes"
 description: "Kubernetes is an open-source system for automating deployment, scaling, and management of containerized applications."
 type: "platform"
-project_lead: "thockin"
+project_lead:
+  - "thockin"
+  - "kubernetes/sig-leads"
 slack_channels:
   - name: "#kubernetes-users"
     workspace: "cncf"
@@ -43,7 +45,10 @@ adopters:
   path: "https://github.com/kubernetes/community/blob/master/ADOPTERS.md"
 
 package_managers:
-  docker: "registry.k8s.io/kube-apiserver"
+  docker:
+    - "registry.k8s.io/kube-apiserver"
+    - "registry.k8s.io/kube-controller-manager"
+    - "registry.k8s.io/kube-scheduler"
   homebrew: "kubernetes-cli"
   chocolatey: "kubernetes-cli"
 

--- a/utilities/dot-project/staleness.go
+++ b/utilities/dot-project/staleness.go
@@ -36,12 +36,19 @@ func CheckStaleness(project Project, lastUpdate time.Time, thresholdDays int) St
 	daysSince := int(time.Since(lastUpdate).Hours() / 24)
 	isStale := daysSince > thresholdDays
 
+	// Strip any leading "@" from each handle before joining so the report
+	// never emits "@@handle" when the value was stored with the prefix.
+	strippedLeads := make([]string, len(project.ProjectLeads))
+	for i, l := range project.ProjectLeads {
+		strippedLeads[i] = strings.TrimPrefix(strings.TrimSpace(l), "@")
+	}
+
 	result := StalenessResult{
 		ProjectSlug:          project.Slug,
 		LastMaintainerUpdate: lastUpdate,
 		DaysSinceUpdate:      daysSince,
 		IsStale:              isStale,
-		ProjectLead:          project.ProjectLead,
+		ProjectLead:          strings.Join(strippedLeads, ", "),
 		SlackChannel:         primarySlackChannel(project),
 	}
 

--- a/utilities/dot-project/staleness_test.go
+++ b/utilities/dot-project/staleness_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCheckStaleness(t *testing.T) {
 	project := validBaseProject()
-	project.ProjectLead = "jdoe"
+	project.ProjectLeads = StringOrSlice{"jdoe"}
 	project.SlackChannels = []SlackChannel{{Name: "#test-project", Primary: true}}
 
 	// Fresh update - not stale

--- a/utilities/dot-project/stringorslice_test.go
+++ b/utilities/dot-project/stringorslice_test.go
@@ -1,0 +1,355 @@
+package projects
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ---------------------------------------------------------------------------
+// StringOrSlice — YAML round-trip tests
+// ---------------------------------------------------------------------------
+
+func TestStringOrSlice_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    StringOrSlice
+		wantErr bool
+	}{
+		{
+			name:  "scalar string",
+			input: `lead: "jdoe"`,
+			want:  StringOrSlice{"jdoe"},
+		},
+		{
+			name:  "single-item list",
+			input: "lead:\n  - jdoe",
+			want:  StringOrSlice{"jdoe"},
+		},
+		{
+			name:  "multi-item list",
+			input: "lead:\n  - jdoe\n  - jsmith",
+			want:  StringOrSlice{"jdoe", "jsmith"},
+		},
+		{
+			name:    "mapping node is rejected",
+			input:   "lead:\n  key: value",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out struct {
+				Lead StringOrSlice `yaml:"lead"`
+			}
+			err := yaml.Unmarshal([]byte(tt.input), &out)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected unmarshal error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+			if len(out.Lead) != len(tt.want) {
+				t.Fatalf("length mismatch: got %v, want %v", out.Lead, tt.want)
+			}
+			for i := range tt.want {
+				if out.Lead[i] != tt.want[i] {
+					t.Errorf("[%d] got %q, want %q", i, out.Lead[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStringOrSlice_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        StringOrSlice
+		wantScalar   bool   // true → expect a plain string, not a YAML list
+		wantContains string // substring that must appear in the marshalled output
+		wantOmitted  bool   // true → expect omitempty to drop the field entirely
+	}{
+		{
+			name:         "single element marshals as scalar",
+			input:        StringOrSlice{"jdoe"},
+			wantScalar:   true,
+			wantContains: "jdoe",
+		},
+		{
+			name:         "multiple elements marshal as list",
+			input:        StringOrSlice{"jdoe", "jsmith"},
+			wantScalar:   false,
+			wantContains: "jdoe",
+		},
+		{
+			name:        "empty slice is omitted by omitempty",
+			input:       StringOrSlice{},
+			wantOmitted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := struct {
+				Lead StringOrSlice `yaml:"lead,omitempty"`
+			}{Lead: tt.input}
+
+			data, err := yaml.Marshal(wrapper)
+			if err != nil {
+				t.Fatalf("unexpected marshal error: %v", err)
+			}
+			out := string(data)
+
+			if tt.wantOmitted {
+				if strings.Contains(out, "lead:") {
+					t.Errorf("expected field to be omitted, got: %s", out)
+				}
+				return
+			}
+
+			if !strings.Contains(out, tt.wantContains) {
+				t.Errorf("expected output to contain %q, got: %s", tt.wantContains, out)
+			}
+
+			if tt.wantScalar {
+				// A scalar marshals as `lead: jdoe\n` — no list dashes
+				if strings.Contains(out, "- ") {
+					t.Errorf("expected scalar output, got list: %s", out)
+				}
+			} else {
+				// A sequence marshals with `- ` entries
+				if !strings.Contains(out, "- ") {
+					t.Errorf("expected list output, got: %s", out)
+				}
+			}
+		})
+	}
+}
+
+// TestStringOrSlice_RoundTrip marshals and then unmarshals, asserting identity.
+func TestStringOrSlice_RoundTrip(t *testing.T) {
+	cases := []StringOrSlice{
+		{"jdoe"},
+		{"jdoe", "jsmith"},
+		{"kubernetes/sig-leads", "thockin"},
+	}
+
+	for _, original := range cases {
+		wrapper := struct {
+			Lead StringOrSlice `yaml:"lead"`
+		}{Lead: original}
+
+		data, err := yaml.Marshal(wrapper)
+		if err != nil {
+			t.Fatalf("marshal error for %v: %v", original, err)
+		}
+
+		var result struct {
+			Lead StringOrSlice `yaml:"lead"`
+		}
+		if err := yaml.Unmarshal(data, &result); err != nil {
+			t.Fatalf("unmarshal error for %v: %v", original, err)
+		}
+
+		if len(result.Lead) != len(original) {
+			t.Errorf("round-trip length mismatch for %v: got %v", original, result.Lead)
+			continue
+		}
+		for i := range original {
+			if result.Lead[i] != original[i] {
+				t.Errorf("round-trip mismatch at [%d] for %v: got %q", i, original, result.Lead[i])
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple project_lead validation
+// ---------------------------------------------------------------------------
+
+func TestProjectLeadMultipleValidation(t *testing.T) {
+	t.Run("two valid handles", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = StringOrSlice{"thockin", "jdoe"}
+		errs := validateProjectStruct(project)
+		for _, e := range errs {
+			if strings.Contains(e, "project_lead") {
+				t.Errorf("unexpected project_lead error: %s", e)
+			}
+		}
+	})
+
+	t.Run("valid handle and valid team", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = StringOrSlice{"thockin", "kubernetes/sig-leads"}
+		errs := validateProjectStruct(project)
+		for _, e := range errs {
+			if strings.Contains(e, "project_lead") {
+				t.Errorf("unexpected project_lead error: %s", e)
+			}
+		}
+	})
+
+	t.Run("one valid and one invalid — only the invalid index errors", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = StringOrSlice{"thockin", "@"} // index 1 is invalid
+		errs := validateProjectStruct(project)
+
+		sawIdx1 := false
+		for _, e := range errs {
+			if strings.Contains(e, "project_lead[0]") {
+				t.Errorf("expected project_lead[0] to be valid, got: %s", e)
+			}
+			if strings.Contains(e, "project_lead[1]") {
+				sawIdx1 = true
+			}
+		}
+		if !sawIdx1 {
+			t.Errorf("expected project_lead[1] error for bare '@', got: %v", errs)
+		}
+	})
+
+	t.Run("all leads invalid produces one error per bad entry", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = StringOrSlice{"@", "org/team/extra"}
+		errs := validateProjectStruct(project)
+
+		sawIdx0, sawIdx1 := false, false
+		for _, e := range errs {
+			if strings.Contains(e, "project_lead[0]") {
+				sawIdx0 = true
+			}
+			if strings.Contains(e, "project_lead[1]") {
+				sawIdx1 = true
+			}
+		}
+		if !sawIdx0 {
+			t.Error("expected error for project_lead[0]")
+		}
+		if !sawIdx1 {
+			t.Error("expected error for project_lead[1]")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// package_managers multi-value and empty-slice validation
+// ---------------------------------------------------------------------------
+
+func TestPackageManagersMultiValue(t *testing.T) {
+	t.Run("multiple images for same registry", func(t *testing.T) {
+		project := validBaseProject()
+		project.PackageManagers = map[string]StringOrSlice{
+			"docker": {
+				"registry.k8s.io/kube-apiserver",
+				"registry.k8s.io/kube-controller-manager",
+			},
+		}
+		errs := validateProjectStruct(project)
+		for _, e := range errs {
+			if strings.Contains(e, "package_managers") {
+				t.Errorf("unexpected package_managers error: %s", e)
+			}
+		}
+	})
+
+	t.Run("empty slice for a key is rejected", func(t *testing.T) {
+		project := validBaseProject()
+		project.PackageManagers = map[string]StringOrSlice{
+			"docker": {},
+		}
+		errs := validateProjectStruct(project)
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, "package_managers.docker") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected package_managers.docker error for empty slice, got: %v", errs)
+		}
+	})
+
+	t.Run("blank string value inside slice is rejected", func(t *testing.T) {
+		project := validBaseProject()
+		project.PackageManagers = map[string]StringOrSlice{
+			"docker": {"valid-image", "   "},
+		}
+		errs := validateProjectStruct(project)
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, "package_managers.docker[1]") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected blank-value error for package_managers.docker[1], got: %v", errs)
+		}
+	})
+
+	t.Run("multiple registries — mixed single and multi", func(t *testing.T) {
+		project := validBaseProject()
+		project.PackageManagers = map[string]StringOrSlice{
+			"docker":   {"img1", "img2"},
+			"homebrew": {"my-tool"},
+			"fedora":   {"my-project"},
+		}
+		errs := validateProjectStruct(project)
+		for _, e := range errs {
+			if strings.Contains(e, "package_managers") {
+				t.Errorf("unexpected package_managers error: %s", e)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Staleness — multiple leads and @ stripping
+// ---------------------------------------------------------------------------
+
+func TestCheckStalenessMultipleLeads(t *testing.T) {
+	staleDate := time.Now().Add(-200 * 24 * time.Hour)
+
+	t.Run("single lead with @ prefix is stripped in output", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = StringOrSlice{"@jdoe"}
+		result := CheckStaleness(project, staleDate, 180)
+		if result.ProjectLead != "jdoe" {
+			t.Errorf("expected '@' stripped to 'jdoe', got %q", result.ProjectLead)
+		}
+	})
+
+	t.Run("multiple leads are joined with comma", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = StringOrSlice{"thockin", "jsmith"}
+		result := CheckStaleness(project, staleDate, 180)
+		if result.ProjectLead != "thockin, jsmith" {
+			t.Errorf("expected 'thockin, jsmith', got %q", result.ProjectLead)
+		}
+	})
+
+	t.Run("multiple leads with @ prefixes are all stripped", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = StringOrSlice{"@thockin", "@jsmith"}
+		result := CheckStaleness(project, staleDate, 180)
+		if result.ProjectLead != "thockin, jsmith" {
+			t.Errorf("expected 'thockin, jsmith', got %q", result.ProjectLead)
+		}
+	})
+
+	t.Run("no leads produces empty string", func(t *testing.T) {
+		project := validBaseProject()
+		project.ProjectLeads = nil
+		result := CheckStaleness(project, staleDate, 180)
+		if result.ProjectLead != "" {
+			t.Errorf("expected empty project_lead, got %q", result.ProjectLead)
+		}
+	})
+}

--- a/utilities/dot-project/template/project.yaml
+++ b/utilities/dot-project/template/project.yaml
@@ -11,7 +11,10 @@ slug: "my-project"              # REQUIRED: lowercase identifier (a-z, 0-9, hyph
 name: "My Project"              # REQUIRED: display name
 description: ""                 # REQUIRED: one-line project description
 type: "project"                 # REQUIRED: project, platform, specification, etc.
-project_lead: "github-handle"   # Optional: GitHub handle or team (org/team-name)
+project_lead: "github-handle"   # Optional: single lead — plain string
+# project_lead:                  # Optional: multiple leads — list form
+#   - "github-handle"
+#   - "org/team-name"
 slack_channels:                 # Optional: one or more CNCF Slack channels
   - name: "#my-project"         # REQUIRED per entry: must start with "#"
     workspace: "cncf"           # Optional: Slack workspace identifier
@@ -33,8 +36,12 @@ artwork: "https://github.com/cncf/artwork/tree/master/projects/my-project"
 #   path: "https://github.com/my-org/my-project/blob/main/ADOPTERS.md"
 
 # package_managers:              # Optional: registry identifiers
-#   docker: "my-org/my-project"
+#   docker: "my-org/my-project"  # single image — plain string
+#   # docker:                    # multiple images — list form
+#   #   - "my-org/my-project"
+#   #   - "my-org/my-project-arm64"
 #   npm: "my-project"
+#   fedora: "my-project"
 
 social:                         # Optional
   twitter: "https://twitter.com/myproject"

--- a/utilities/dot-project/types.go
+++ b/utilities/dot-project/types.go
@@ -1,9 +1,59 @@
 package projects
 
 import (
+	"fmt"
 	"net/http"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
+
+// StringOrSlice is a YAML/JSON type that accepts both a plain string scalar
+// and a sequence of strings. Single-element values round-trip as a plain
+// string for backward-compatible YAML output; multi-element values serialize
+// as a YAML list.
+//
+// Used for:
+//   - project_lead  — supports multiple leads
+//   - package_managers values — supports multiple images/packages per registry
+type StringOrSlice []string
+
+// UnmarshalYAML allows project.yaml files to use either form:
+//
+//	project_lead: "jdoe"          # scalar (backward-compatible)
+//	project_lead:                 # list
+//	  - "jdoe"
+//	  - "jsmith"
+func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		*s = StringOrSlice{value.Value}
+		return nil
+	case yaml.SequenceNode:
+		var ss []string
+		if err := value.Decode(&ss); err != nil {
+			return err
+		}
+		*s = ss
+		return nil
+	default:
+		return fmt.Errorf("expected string or sequence, got YAML node type %v", value.Tag)
+	}
+}
+
+// MarshalYAML serializes a single-element StringOrSlice as a plain string
+// scalar (readable, backward-compatible). Multi-element values serialize as a
+// YAML sequence. An empty slice serializes as nil (omitempty will drop it).
+func (s StringOrSlice) MarshalYAML() (interface{}, error) {
+	switch len(s) {
+	case 0:
+		return nil, nil
+	case 1:
+		return s[0], nil
+	default:
+		return []string(s), nil
+	}
+}
 
 type Project struct {
 	Name         string            `json:"name" yaml:"name"`
@@ -18,7 +68,10 @@ type Project struct {
 	Adopters     *PathRef          `json:"adopters,omitempty" yaml:"adopters,omitempty"` // Link to ADOPTERS.md or similar
 
 	// Distribution
-	PackageManagers map[string]string `json:"package_managers,omitempty" yaml:"package_managers,omitempty"` // Registry identifiers (e.g., npm, pypi, docker)
+	// PackageManagers maps registry names to one or more identifiers.
+	// A single identifier may be given as a plain string; multiple identifiers
+	// (e.g., multi-arch Docker images) may be given as a list.
+	PackageManagers map[string]StringOrSlice `json:"package_managers,omitempty" yaml:"package_managers,omitempty"`
 
 	// Schema and identification
 	SchemaVersion string `json:"schema_version" yaml:"schema_version"`
@@ -26,8 +79,10 @@ type Project struct {
 	Slug          string `json:"slug" yaml:"slug"` // Unique project identifier (lowercase, alphanumeric + hyphens)
 
 	// Contacts and channels
-	ProjectLead string `json:"project_lead,omitempty" yaml:"project_lead,omitempty"` // GitHub handle of primary contact
-
+	// ProjectLeads holds one or more GitHub handles or GitHub team references
+	// (org/team-name) for the project lead(s). Accepts a plain string (single
+	// lead, backward-compatible) or a YAML list (multiple leads).
+	ProjectLeads StringOrSlice `json:"project_lead,omitempty" yaml:"project_lead,omitempty"`
 
 	// SlackChannels lists one or more Slack channels for the project.
 	// Mark the channel most end-users should join with primary: true.

--- a/utilities/dot-project/validator.go
+++ b/utilities/dot-project/validator.go
@@ -51,12 +51,12 @@ func (pv *ProjectValidator) ValidateProjects() ([]ValidationResult, error) {
 	}
 
 	var results []ValidationResult
-	for _, url := range projectURLs {
-		result, err := pv.validateProject(url)
+	for _, projectURL := range projectURLs {
+		result, err := pv.validateProject(projectURL)
 		if err != nil {
-			log.Printf("Error validating project %s: %v", url, err)
+			log.Printf("Error validating project %s: %v", projectURL, err)
 			result = ValidationResult{
-				URL:         url,
+				URL:         projectURL,
 				Valid:       false,
 				Errors:      []string{err.Error()},
 				LastChecked: time.Now(),
@@ -187,7 +187,7 @@ func (pv *ProjectValidator) fetchContent(url string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
@@ -236,25 +236,25 @@ func validateProjectStruct(project Project) []string {
 		errors = append(errors, fmt.Sprintf("slug must be lowercase alphanumeric with hyphens, got: %s", project.Slug))
 	}
 
-	// Validate project_lead (optional but must be non-empty if present)
-	// Accepts either a GitHub handle (e.g., "jdoe") or a GitHub team (e.g., "org/team-name")
-	if project.ProjectLead != "" {
-		lead := strings.TrimSpace(project.ProjectLead)
+	// Validate project_lead (optional; each entry must be a valid GitHub handle
+	// or a GitHub team reference of the form org/team-name).
+	// Accepts a single string (scalar) or a list for projects with multiple leads.
+	for i, rawLead := range project.ProjectLeads {
+		lead := strings.TrimSpace(rawLead)
 		lead = strings.TrimPrefix(lead, "@")
 		if lead == "" {
-			errors = append(errors, "project_lead cannot be empty or just '@'")
+			errors = append(errors, fmt.Sprintf("project_lead[%d] cannot be empty or just '@'", i))
 		} else if strings.Contains(lead, "/") {
 			parts := strings.Split(lead, "/")
 			if len(parts) != 2 {
-				errors = append(errors, fmt.Sprintf("project_lead team format must be org/team-name (got too many segments): %s", project.ProjectLead))
+				errors = append(errors, fmt.Sprintf("project_lead[%d] team format must be org/team-name (got too many segments): %s", i, rawLead))
 			} else if parts[0] == "" {
-				errors = append(errors, fmt.Sprintf("project_lead team format requires a non-empty org (expected org/team-name): %s", project.ProjectLead))
+				errors = append(errors, fmt.Sprintf("project_lead[%d] team format requires a non-empty org (expected org/team-name): %s", i, rawLead))
 			} else if parts[1] == "" {
-				errors = append(errors, fmt.Sprintf("project_lead team format requires a non-empty team name (expected org/team-name): %s", project.ProjectLead))
+				errors = append(errors, fmt.Sprintf("project_lead[%d] team format requires a non-empty team name (expected org/team-name): %s", i, rawLead))
 			}
 		}
 	}
-
 
 	// Validate slack_channels (optional list of structured channels)
 	primarySlackCount := 0
@@ -342,9 +342,9 @@ func validateProjectStruct(project Project) []string {
 	}
 
 	// Validate social links
-	for platform, url := range project.Social {
-		if !isValidURL(url) {
-			errors = append(errors, fmt.Sprintf("social.%s is not a valid URL: %s", platform, url))
+	for platform, rawURL := range project.Social {
+		if !isValidURL(rawURL) {
+			errors = append(errors, fmt.Sprintf("social.%s is not a valid URL: %s", platform, rawURL))
 		}
 	}
 
@@ -441,6 +441,18 @@ func validateProjectStruct(project Project) []string {
 				{project.Legal.IdentityType.DCOURL, "legal.identity_type.dco_url"},
 				{project.Legal.IdentityType.CLAURL, "legal.identity_type.cla_url"},
 			})...)
+		}
+	}
+
+	// Validate package_managers: each key must have at least one non-empty value.
+	for key, vals := range project.PackageManagers {
+		if len(vals) == 0 {
+			errors = append(errors, fmt.Sprintf("package_managers.%s must have at least one value", key))
+		}
+		for j, v := range vals {
+			if strings.TrimSpace(v) == "" {
+				errors = append(errors, fmt.Sprintf("package_managers.%s[%d] value must not be empty", key, j))
+			}
 		}
 	}
 

--- a/utilities/dot-project/validator_test.go
+++ b/utilities/dot-project/validator_test.go
@@ -11,7 +11,7 @@ import (
 func TestValidator(t *testing.T) {
 	// Create a test cache directory
 	cacheDir := ".test-cache"
-	defer os.RemoveAll(cacheDir)
+	defer func() { _ = os.RemoveAll(cacheDir) }()
 
 	_ = NewValidator(cacheDir) // Test that constructor works
 
@@ -97,8 +97,8 @@ func TestMaturityLogValidation(t *testing.T) {
 
 	for _, expectedError := range expectedErrors {
 		found := false
-		for _, error := range errors {
-			if error == expectedError {
+		for _, e := range errors {
+			if e == expectedError {
 				found = true
 				break
 			}
@@ -128,8 +128,8 @@ func TestAuditsValidation(t *testing.T) {
 
 	for _, expectedError := range expectedErrors {
 		found := false
-		for _, error := range errors {
-			if error == expectedError {
+		for _, e := range errors {
+			if e == expectedError {
 				found = true
 				break
 			}
@@ -156,8 +156,8 @@ func TestRepositoriesValidation(t *testing.T) {
 
 	for _, expectedError := range expectedErrors {
 		found := false
-		for _, error := range errors {
-			if error == expectedError {
+		for _, e := range errors {
+			if e == expectedError {
 				found = true
 				break
 			}
@@ -340,8 +340,8 @@ func TestNewFieldsValidation(t *testing.T) {
 
 	for _, expectedError := range expectedErrors {
 		found := false
-		for _, error := range errors {
-			if error == expectedError {
+		for _, e := range errors {
+			if e == expectedError {
 				found = true
 				break
 			}
@@ -502,7 +502,9 @@ func TestProjectLeadValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			project := validBaseProject()
-			project.ProjectLead = tt.lead
+			if tt.lead != "" {
+				project.ProjectLeads = StringOrSlice{tt.lead}
+			}
 			errs := validateProjectStruct(project)
 
 			hasLeadError := false
@@ -524,7 +526,6 @@ func TestProjectLeadValidation(t *testing.T) {
 		})
 	}
 }
-
 
 func TestSlackChannelsValidation(t *testing.T) {
 	tests := []struct {
@@ -725,9 +726,9 @@ func TestIdentityTypeValidation(t *testing.T) {
 func TestPackageManagersValidation(t *testing.T) {
 	t.Run("valid entries", func(t *testing.T) {
 		project := validBaseProject()
-		project.PackageManagers = map[string]string{
-			"docker": "kubernetes/kubectl",
-			"npm":    "@kubernetes/client-node",
+		project.PackageManagers = map[string]StringOrSlice{
+			"docker": {"kubernetes/kubectl"},
+			"npm":    {"@kubernetes/client-node"},
 		}
 		errs := validateProjectStruct(project)
 		for _, e := range errs {


### PR DESCRIPTION
- Add StringOrSlice type: accepts a plain string scalar or a YAML list, backward-compatible with all existing project.yaml files
- project_lead now accepts one or more GitHub handles.
- package_managers values now accept one or more identifiers per registry