### PR TITLE
fix: skip orgs that block the token in onboarding-report

### DIFF
--- a/utilities/dot-project/cmd/onboarding-report/main.go
+++ b/utilities/dot-project/cmd/onboarding-report/main.go
@@ -76,7 +76,7 @@ func main() {
 	client := &http.Client{Timeout: projects.DefaultHTTPTimeout}
 
 	log.Printf("Fetching organizations from enterprise: %s", *enterprise)
-	orgs, err := listEnterpriseOrgs(client, ghToken, *enterprise)
+	orgs, err := listEnterpriseOrgs(client, projects.DefaultGitHubGraphQLURL, ghToken, *enterprise)
 	if err != nil {
 		log.Fatalf("Failed to list enterprise orgs: %v", err)
 	}
@@ -127,8 +127,10 @@ func main() {
 }
 
 // listEnterpriseOrgs uses the GitHub GraphQL API to paginate through all
-// organizations in the enterprise.
-func listEnterpriseOrgs(client *http.Client, token, enterprise string) ([]string, error) {
+// organizations in the enterprise. Organizations that block the token (e.g.
+// orgs that forbid classic PATs) are skipped with a warning rather than
+// failing the whole listing.
+func listEnterpriseOrgs(client *http.Client, apiURL, token, enterprise string) ([]string, error) {
 	var allOrgs []string
 	var cursor *string
 
@@ -166,7 +168,7 @@ query($enterprise: String!, $first: Int!, $after: String) {
 			return nil, fmt.Errorf("marshaling request: %w", err)
 		}
 
-		req, err := http.NewRequest("POST", projects.DefaultGitHubGraphQLURL, bytes.NewReader(bodyBytes))
+		req, err := http.NewRequest("POST", apiURL, bytes.NewReader(bodyBytes))
 		if err != nil {
 			return nil, err
 		}
@@ -197,11 +199,19 @@ query($enterprise: String!, $first: Int!, $after: String) {
 		}
 
 		if len(gqlResp.Errors) > 0 {
-			msgs := make([]string, len(gqlResp.Errors))
-			for i, e := range gqlResp.Errors {
-				msgs[i] = e.Message
+			// Errors without any data mean the request itself failed (bad
+			// credentials, missing scope). Errors alongside data are per-org
+			// access blocks; keep the orgs that did come back.
+			if gqlResp.Data.Enterprise.Organizations.Nodes == nil {
+				msgs := make([]string, len(gqlResp.Errors))
+				for i, e := range gqlResp.Errors {
+					msgs[i] = e.Message
+				}
+				return nil, fmt.Errorf("GraphQL errors: %s", strings.Join(msgs, "; "))
 			}
-			return nil, fmt.Errorf("GraphQL errors: %s", strings.Join(msgs, "; "))
+			for _, e := range gqlResp.Errors {
+				log.Printf("Warning: skipping inaccessible org: %s", e.Message)
+			}
 		}
 
 		// If the enterprise field is null/empty, the token likely lacks read:enterprise scope.
@@ -215,6 +225,10 @@ query($enterprise: String!, $first: Int!, $after: String) {
 
 		nodes := gqlResp.Data.Enterprise.Organizations.Nodes
 		for _, n := range nodes {
+			// Orgs the token cannot access surface as null nodes.
+			if n.Login == "" {
+				continue
+			}
 			allOrgs = append(allOrgs, n.Login)
 		}
 

--- a/utilities/dot-project/cmd/onboarding-report/main_test.go
+++ b/utilities/dot-project/cmd/onboarding-report/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// newGraphQLServer serves the given JSON responses in order, one per request.
+func newGraphQLServer(t *testing.T, responses []string) *httptest.Server {
+	t.Helper()
+	i := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if i >= len(responses) {
+			t.Errorf("unexpected request #%d", i+1)
+			http.Error(w, "too many requests", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(responses[i])); err != nil {
+			t.Errorf("writing response: %v", err)
+		}
+		i++
+	}))
+}
+
+func TestListEnterpriseOrgsSkipsBlockedOrgs(t *testing.T) {
+	// Orgs that forbid the token come back as null nodes plus a top-level
+	// error, alongside the accessible orgs (partial data).
+	resp := `{
+		"data": {"enterprise": {"organizations": {
+			"nodes": [{"login": "org-a"}, null, {"login": "org-b"}, null],
+			"pageInfo": {"hasNextPage": false, "endCursor": ""}
+		}}},
+		"errors": [
+			{"message": "'kubearmor' forbids access via a personal access token (classic)."},
+			{"message": "'openfga' forbids access via a personal access token (classic)."}
+		]
+	}`
+	srv := newGraphQLServer(t, []string{resp})
+	defer srv.Close()
+
+	orgs, err := listEnterpriseOrgs(srv.Client(), srv.URL, "test-token", "cncf")
+	if err != nil {
+		t.Fatalf("listEnterpriseOrgs returned error: %v", err)
+	}
+	want := []string{"org-a", "org-b"}
+	if !reflect.DeepEqual(orgs, want) {
+		t.Errorf("orgs = %v, want %v", orgs, want)
+	}
+}
+
+func TestListEnterpriseOrgsFailsWithoutData(t *testing.T) {
+	resp := `{
+		"data": {"enterprise": null},
+		"errors": [{"message": "Bad credentials"}]
+	}`
+	srv := newGraphQLServer(t, []string{resp})
+	defer srv.Close()
+
+	_, err := listEnterpriseOrgs(srv.Client(), srv.URL, "test-token", "cncf")
+	if err == nil {
+		t.Fatal("expected error when response has errors and no data, got nil")
+	}
+	if !strings.Contains(err.Error(), "Bad credentials") {
+		t.Errorf("error %q does not mention the GraphQL error message", err)
+	}
+}
+
+func TestListEnterpriseOrgsPaginates(t *testing.T) {
+	page1 := `{
+		"data": {"enterprise": {"organizations": {
+			"nodes": [{"login": "org-a"}],
+			"pageInfo": {"hasNextPage": true, "endCursor": "cursor-1"}
+		}}}
+	}`
+	page2 := `{
+		"data": {"enterprise": {"organizations": {
+			"nodes": [{"login": "org-b"}],
+			"pageInfo": {"hasNextPage": false, "endCursor": ""}
+		}}}
+	}`
+	srv := newGraphQLServer(t, []string{page1, page2})
+	defer srv.Close()
+
+	orgs, err := listEnterpriseOrgs(srv.Client(), srv.URL, "test-token", "cncf")
+	if err != nil {
+		t.Fatalf("listEnterpriseOrgs returned error: %v", err)
+	}
+	want := []string{"org-a", "org-b"}
+	if !reflect.DeepEqual(orgs, want) {
+		t.Errorf("orgs = %v, want %v", orgs, want)
+	}
+}


### PR DESCRIPTION
In the onboarding-report workflow, some orgs don't allow API access via classic PATs and that caused the entire workflow to fail, instead skip them. 