### PR TITLE
Fix setup-python action for removed pip-install arg

### DIFF
--- a/.github/workflows/change-file-build-new-actions-vm.yml
+++ b/.github/workflows/change-file-build-new-actions-vm.yml
@@ -67,7 +67,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Verify OCI CLI
         run: oci compute image list --compartment-id ${{ env.COMPARTMENT_ID }} --operating-system runner-images --operating-system-version 123456
@@ -160,7 +162,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Verify OCI CLI
         run: oci compute image list --compartment-id ${{ env.COMPARTMENT_ID }} --operating-system runner-images --operating-system-version 123456
@@ -360,7 +364,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Release
         run: |
@@ -386,7 +392,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Sync image to other regions
         run: |
@@ -415,7 +423,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Release
         run: |
@@ -447,7 +457,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Import Custom Image
         run: |

--- a/.github/workflows/cleanup-custom-images.yaml
+++ b/.github/workflows/cleanup-custom-images.yaml
@@ -28,7 +28,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Cleanup bucket objects
         run: |

--- a/.github/workflows/periodic-build-new-actions-vm.yml
+++ b/.github/workflows/periodic-build-new-actions-vm.yml
@@ -40,7 +40,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Verify OCI CLI
         run: oci compute image list --compartment-id ${{ env.COMPARTMENT_ID }} --operating-system runner-images --operating-system-version 123456
@@ -165,7 +167,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Verify OCI CLI
         run: oci compute image list --compartment-id ${{ env.COMPARTMENT_ID }} --operating-system runner-images --operating-system-version 123456
@@ -398,7 +402,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Release
         run: |
@@ -424,7 +430,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Sync image to other regions
         run: |
@@ -453,7 +461,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Release
         run: |
@@ -485,7 +495,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
-          pip-install: oci-cli
+
+      - name: Install OCI CLI packages
+        run: pip install oci-cli
 
       - name: Import Custom Image on Ashburn
         run: |


### PR DESCRIPTION
`pip-install` parameter is removed in v7.0.0 of the setup-python action.