### PR TITLE
Migrate SeeBom to BOMHort with v0.6.0

### DIFF
--- a/ci/cluster/services/apps/bomhort.yaml
+++ b/ci/cluster/services/apps/bomhort.yaml
@@ -1,0 +1,84 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bomhort
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "25"
+    notifications.argoproj.io/subscribe.slack: internal-gha-argo
+  labels:
+    cluster: oke-cncf-automation
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/seebom-labs/bomhort/charts
+    chart: bomhort
+    targetRevision: 0.6.0
+    helm:
+      values: |
+        cleanBatchJobs: false
+        clickhouse:
+          database: bomhort
+          host: chi-bomhort-clickhouse-bomhort-cluster-0-0
+          installation:
+            podTemplate:
+              containerImage: docker.io/clickhouse/clickhouse-server:24.8
+              resources:
+                limits:
+                  cpu: "4"
+                  memory: 16Gi
+                requests:
+                  cpu: "2"
+                  memory: 8Gi
+            volumeClaimTemplate:
+              dataStorage: 500Gi
+              logStorage: 10Gi
+          port: 9000
+          user: default
+          userPasswordSecret:
+            enabled: true
+            key: password
+            secretName: clickhouse-password
+        gitSync:
+          enabled: false
+        image:
+          registry: ghcr.io
+          repository: seebom-labs/bomhort
+          tag: 0.6.0
+        sbomSource:
+          mountPath: /data/sboms
+          pvcName: bomhort-sbom-data
+          storageSize: 20Gi
+        seedJob:
+          cncfExceptionsURL: https://raw.githubusercontent.com/cncf/foundation/main/license-exceptions/exceptions.json
+          sbomBranch: main
+          sbomRepo: https://github.com/cncf/sbom.git
+        s3:
+          buckets: '[{"name":"cncf-subproject-sboms","endpoint":"axtwf1hkrwcy.compat.objectstorage.us-sanjose-1.oraclecloud.com","region":"us-sanjose-1"},{"name":"cncf-project-sboms","endpoint":"axtwf1hkrwcy.compat.objectstorage.us-sanjose-1.oraclecloud.com","region":"us-sanjose-1"}]'
+        dataMigration:
+          enabled: true
+          source:
+            host: chi-seebom-clickhouse-seebom-cluster-0-0.seebom.svc.cluster.local
+            port: 9000
+            database: seebom
+            user: default
+            passwordSecret:
+              secretName: clickhouse-migration-source
+              key: password
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: bomhort
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: batch
+      kind: Job
+      jqPathExpressions:
+        - .status
+        - .spec.selector
+        - .spec.template.metadata.labels

--- a/ci/cluster/services/manifests/envoy-gateway/http-routes.yaml
+++ b/ci/cluster/services/manifests/envoy-gateway/http-routes.yaml
@@ -1,19 +1,20 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: seebom
-  namespace: seebom
+  name: bomhort
+  namespace: bomhort
   labels:
     use-shared-gateway: "true"
 spec:
   hostnames:
   - seebom.cncf.io
+  - bomhort.cncf.io
   parentRefs:
   - name: shared-gateway
     namespace: envoy-gateway
   rules:
   - backendRefs:
-    - name: seebom-ui
+    - name: bomhort-ui
       port: 80
     matches:
     - path:

--- a/ci/cluster/services/manifests/external-secrets/bomhort.yaml
+++ b/ci/cluster/services/manifests/external-secrets/bomhort.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bomhort-secret
+  namespace: bomhort
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: oci-secret-store
+  target:
+    name: bomhort-secret
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: seebom-secret


### PR DESCRIPTION
The SeeBom deployment will be removed later when the data is migrated to the new database.