### PR TITLE
GHA runner config updates for cost optimization

### DIFF
--- a/.github/workflows/publish-cloudrunner-images.yml
+++ b/.github/workflows/publish-cloudrunner-images.yml
@@ -162,24 +162,28 @@ jobs:
         include:
           - runner: "amd64"
             arch: "amd64"
-            shape: "VM.Standard.E6.Flex,VM.Standard.E5.Flex,VM.Standard.E4.Flex"
+            shape: "VM.Standard.E5.Flex,VM.Standard.E4.Flex"
             ocpus: 2
             memory: 8.0
+            preemptible: true
           - runner: "arm64"
             arch: "arm64"
             shape: "VM.Standard.A1.Flex"
             ocpus: 2
             memory: 8.0
+            preemptible: true
           - runner: "gpu-a10-1"
             arch: "amd64"
             shape: "VM.GPU.A10.1"
             ocpus: 0   # Not a flex type, so ocpus and memory are determined by the shape
             memory: 0
+            preemptible: false
           - runner: "gpu-a10-2"
             arch: "amd64"
             shape: "VM.GPU.A10.2"
             ocpus: 0   # Not a flex type, so ocpus and memory are determined by the shape
             memory: 0
+            preemptible: false
     steps:
       - name: Test the published Cloudrunner Docker image
         run: |
@@ -211,4 +215,5 @@ jobs:
             --subnet-id=${{ env.SUBNET_ID }} \
             --fallback-region=${{ env.FALLBACK_REGION }} \
             --fallback-availability-domain=${{ env.FALLBACK_AVAILABILITY_DOMAIN }} \
-            --fallback-subnet-id=${{ env.FALLBACK_SUBNET_ID }}
+            --fallback-subnet-id=${{ env.FALLBACK_SUBNET_ID }} \
+            --preemptible=${{ matrix.preemptible }}

--- a/ci/cloudrunners/oci/main.go
+++ b/ci/cloudrunners/oci/main.go
@@ -43,7 +43,9 @@ var args struct {
 	shape              string
 	shapeOcpus         float32
 	shapeMemoryInGBs   float32
+	bootVolumeSizeGB   int64
 	runEnv             string
+	preemptible        bool
 
 	fallbackRegion             string
 	fallbackAvailabilityDomain string
@@ -218,8 +220,8 @@ func tryLaunch(ctx context.Context, region regionConfig, shape string, sshKeyPai
 		},
 		SourceDetails: &core.InstanceSourceViaImageDetails{
 			ImageId:             common.String(*latestImage.Id),
-			BootVolumeSizeInGBs: common.Int64(600),
-			BootVolumeVpusPerGB: common.Int64(120),
+			BootVolumeSizeInGBs: common.Int64(args.bootVolumeSizeGB),
+			BootVolumeVpusPerGB: common.Int64(30),
 		},
 		AgentConfig: &core.LaunchInstanceAgentConfigDetails{
 			PluginsConfig: []core.InstanceAgentPluginConfigDetails{{
@@ -231,12 +233,22 @@ func tryLaunch(ctx context.Context, region regionConfig, shape string, sshKeyPai
 		},
 	}
 
+	if args.preemptible {
+		launchDetails.PreemptibleInstanceConfig = &core.PreemptibleInstanceConfigDetails{
+			PreemptionAction: core.TerminatePreemptionAction{
+				PreserveBootVolume: common.Bool(false),
+			},
+		}
+	}
+
 	// Only set flexible shape config when OCPUs/memory are specified and
 	// the shape is actually flexible.
+	// OCI counts 1 OCPU = 2 vCPUs. The flag accepts vCPUs for a 1:1 mapping,
+	// so we divide by 2 to get the OCPU value the API expects.
 	if args.shapeMemoryInGBs > 0.0 && args.shapeOcpus > 0.0 && strings.Contains(shape, "Flex") {
 		launchDetails.ShapeConfig = &core.LaunchInstanceShapeConfigDetails{
 			MemoryInGBs: common.Float32(args.shapeMemoryInGBs),
-			Ocpus:       common.Float32(args.shapeOcpus),
+			Ocpus:       common.Float32(args.shapeOcpus / 2),
 		}
 	}
 
@@ -370,7 +382,7 @@ func init() {
 		&args.shapeOcpus,
 		"shape-ocpus",
 		0.0, // Default to 0, indicating not set.
-		"Number of OCPUs for flexible shapes (e.g., 1.0, 2.0). Required if a '.Flex' shape is used.",
+		"Number of CPUs for flexible shapes (e.g., 1.0, 2.0). Required if a '.Flex' shape is used.",
 	)
 	flags.Float32Var(
 		&args.shapeMemoryInGBs,
@@ -383,6 +395,18 @@ func init() {
 		"running-environment",
 		"production",
 		"Running Environment: production or ci",
+	)
+	flags.BoolVar(
+		&args.preemptible,
+		"preemptible",
+		true,
+		"Launch preemptible (spot) instances for lower cost. Instance may be reclaimed by OCI at any time.",
+	)
+	flags.Int64Var(
+		&args.bootVolumeSizeGB,
+		"boot-volume-size-gb",
+		300,
+		"Boot volume size in GB",
 	)
 	flags.StringVar(
 		&args.fallbackRegion,


### PR DESCRIPTION
We need some changes for cost optimization on Oracle:

1. Change boot volume size to 300 by default (it's configurable by a command-line parameter)
2. Make the VMs preemptible by default (it's configurable by a command-line parameter)
3. Make the OCPU - vCPU mapping 1:1 (by default, 1 OCPU is 2 vCPUs)