### PR TITLE
Reduce OCI runner preemption impact and auto re-run preempted jobs

### DIFF
--- a/.github/workflows/publish-cloudrunner-images.yml
+++ b/.github/workflows/publish-cloudrunner-images.yml
@@ -24,6 +24,9 @@ env:
   REGISTRY: ghcr.io
   # IMAGE_NAME maps to the Docker image name
   IMAGE_NAME: cncf/gha-cloudrunner
+  # Fork PRs get a read-only GITHUB_TOKEN and no secrets: build without
+  # pushing and skip jobs that need the pushed image or OCI credentials.
+  IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
 jobs:
   build-cloudrunner-images:
@@ -54,9 +57,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      # Login against a Docker registry except on PR
+      # Login against a Docker registry except on fork PRs
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
+        if: env.IS_FORK_PR != 'true'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -82,7 +86,7 @@ jobs:
         with:
           context: ./ci/cloudrunners/
           platforms: linux/amd64
-          push: true
+          push: ${{ env.IS_FORK_PR != 'true' }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ./ci/cloudrunners/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -146,6 +150,7 @@ jobs:
   # Test the published image by running it and see if the VM is created.
   test-image:
     needs: build-cloudrunner-images
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,7 @@ crash.*.log
 **/kubeconfig.yaml
 **/kubeconfig.yml
 
+# Local working proposals
+ci/proposals/
+
 .DS_Store

--- a/ci/cloudrunners/oci/main.go
+++ b/ci/cloudrunners/oci/main.go
@@ -79,6 +79,26 @@ func isOutOfCapacityError(err error) bool {
 	return false
 }
 
+// splitAndTrim splits a comma-separated flag value into trimmed, non-empty items.
+func splitAndTrim(s string) []string {
+	var items []string
+	for _, item := range strings.Split(s, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+// vcpusPerOcpu returns how many vCPUs OCI exposes per OCPU for the given
+// shape: 1 for Ampere ARM shapes (no SMT), 2 for x86 shapes.
+func vcpusPerOcpu(shape string) float32 {
+	if strings.HasPrefix(shape, "VM.Standard.A") || strings.HasPrefix(shape, "BM.Standard.A") {
+		return 1
+	}
+	return 2
+}
+
 // findImage returns the latest GHA runner image available in the current region of the given compute client.
 func findImage(ctx context.Context, computeClient core.ComputeClient, compartmentId, arch, runEnv string) (*core.Image, error) {
 	osname := fmt.Sprintf("ubuntu-24.04-%s-gha-image", arch)
@@ -110,28 +130,31 @@ func run(cmd *cobra.Command, argv []string) error {
 	defer cancel()
 
 	// Parse the comma-separated shape list (single value is fine too).
-	shapes := strings.Split(args.shape, ",")
-	for i := range shapes {
-		shapes[i] = strings.TrimSpace(shapes[i])
-	}
+	shapes := splitAndTrim(args.shape)
 
-	// Build the ordered list of regions: primary (from flags) + fallbacks.
-	regions := []regionConfig{
-		{
+	// Build the ordered list of launch targets: every AD of the primary
+	// region (from flags), then every AD of the fallback region. ADs are
+	// comma-separated; subnets are regional in OCI so one subnet ID covers
+	// all ADs of its region.
+	var regions []regionConfig
+	for _, ad := range splitAndTrim(args.availabilityDomain) {
+		regions = append(regions, regionConfig{
 			Region:             args.region,
-			AvailabilityDomain: args.availabilityDomain,
+			AvailabilityDomain: ad,
 			SubnetID:           args.subnetId,
-		},
+		})
 	}
 	if args.fallbackRegion != "" {
 		if args.fallbackAvailabilityDomain == "" || args.fallbackSubnetId == "" {
 			return fmt.Errorf("--fallback-availability-domain and --fallback-subnet-id are required when --fallback-region is set")
 		}
-		regions = append(regions, regionConfig{
-			Region:             args.fallbackRegion,
-			AvailabilityDomain: args.fallbackAvailabilityDomain,
-			SubnetID:           args.fallbackSubnetId,
-		})
+		for _, ad := range splitAndTrim(args.fallbackAvailabilityDomain) {
+			regions = append(regions, regionConfig{
+				Region:             args.fallbackRegion,
+				AvailabilityDomain: ad,
+				SubnetID:           args.fallbackSubnetId,
+			})
+		}
 	}
 
 	// Create SSH key pair once — reused across retry attempts.
@@ -177,7 +200,15 @@ func run(cmd *cobra.Command, argv []string) error {
 			}()
 
 			log.Printf("instance launched successfully: region=%s shape=%s", region.Region, shape)
-			return runOnMachine(ctx, machine, sshKeyPair)
+			err = runOnMachine(ctx, machine, sshKeyPair)
+			if err != nil && args.preemptible {
+				if state, stateErr := machine.LifecycleState(context.Background()); stateErr == nil &&
+					(state == core.InstanceLifecycleStateTerminating || state == core.InstanceLifecycleStateTerminated) {
+					log.Printf("INSTANCE PREEMPTED: region=%s ad=%s shape=%s state=%s: instance was reclaimed by OCI while the job was running",
+						region.Region, region.AvailabilityDomain, shape, state)
+				}
+			}
+			return err
 		}
 	}
 
@@ -243,12 +274,14 @@ func tryLaunch(ctx context.Context, region regionConfig, shape string, sshKeyPai
 
 	// Only set flexible shape config when OCPUs/memory are specified and
 	// the shape is actually flexible.
-	// OCI counts 1 OCPU = 2 vCPUs. The flag accepts vCPUs for a 1:1 mapping,
-	// so we divide by 2 to get the OCPU value the API expects.
+	// The --shape-ocpus flag accepts vCPUs so runner labels map 1:1 to CPUs.
+	// On x86 shapes (E4/E5/E6) 1 OCPU = 2 vCPUs (SMT), so we divide by 2.
+	// On Ampere ARM shapes (A1/A2) there is no SMT: 1 OCPU = 1 vCPU, so the
+	// value is passed through unchanged.
 	if args.shapeMemoryInGBs > 0.0 && args.shapeOcpus > 0.0 && strings.Contains(shape, "Flex") {
 		launchDetails.ShapeConfig = &core.LaunchInstanceShapeConfigDetails{
 			MemoryInGBs: common.Float32(args.shapeMemoryInGBs),
-			Ocpus:       common.Float32(args.shapeOcpus / 2),
+			Ocpus:       common.Float32(args.shapeOcpus / vcpusPerOcpu(shape)),
 		}
 	}
 
@@ -358,7 +391,7 @@ func init() {
 		&args.availabilityDomain,
 		"availability-domain",
 		"bzBe:US-SANJOSE-1-AD-1",
-		"Availability Domain",
+		"Comma-separated list of Availability Domains to try in order",
 	)
 	flags.StringVar(
 		&args.compartmentId,
@@ -417,8 +450,8 @@ func init() {
 	flags.StringVar(
 		&args.fallbackAvailabilityDomain,
 		"fallback-availability-domain",
-		"bzBe:US-ASHBURN-AD-1",
-		"Availability domain for the fallback region",
+		"bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3",
+		"Comma-separated list of Availability Domains to try in order in the fallback region",
 	)
 	flags.StringVar(
 		&args.fallbackSubnetId,

--- a/ci/cloudrunners/oci/main.go
+++ b/ci/cloudrunners/oci/main.go
@@ -48,9 +48,9 @@ var args struct {
 	preemptible        bool
 	preemptionQueue    string
 
-	fallbackRegion             string
-	fallbackAvailabilityDomain string
-	fallbackSubnetId           string
+	fallbackRegions             []string
+	fallbackAvailabilityDomains []string
+	fallbackSubnetIds           []string
 }
 
 // exitCodePreempted is the sentinel exit code the launcher uses when the
@@ -155,15 +155,16 @@ func run(cmd *cobra.Command, argv []string) error {
 			SubnetID:           args.subnetId,
 		})
 	}
-	if args.fallbackRegion != "" {
-		if args.fallbackAvailabilityDomain == "" || args.fallbackSubnetId == "" {
-			return fmt.Errorf("--fallback-availability-domain and --fallback-subnet-id are required when --fallback-region is set")
-		}
-		for _, ad := range splitAndTrim(args.fallbackAvailabilityDomain) {
+	if len(args.fallbackRegions) != len(args.fallbackAvailabilityDomains) || len(args.fallbackRegions) != len(args.fallbackSubnetIds) {
+		return fmt.Errorf("--fallback-region, --fallback-availability-domain and --fallback-subnet-id must be repeated the same number of times (got %d/%d/%d)",
+			len(args.fallbackRegions), len(args.fallbackAvailabilityDomains), len(args.fallbackSubnetIds))
+	}
+	for i, fallbackRegion := range args.fallbackRegions {
+		for _, ad := range splitAndTrim(args.fallbackAvailabilityDomains[i]) {
 			regions = append(regions, regionConfig{
-				Region:             args.fallbackRegion,
+				Region:             fallbackRegion,
 				AvailabilityDomain: ad,
-				SubnetID:           args.fallbackSubnetId,
+				SubnetID:           args.fallbackSubnetIds[i],
 			})
 		}
 	}
@@ -466,22 +467,22 @@ func init() {
 		300,
 		"Boot volume size in GB",
 	)
-	flags.StringVar(
-		&args.fallbackRegion,
+	flags.StringArrayVar(
+		&args.fallbackRegions,
 		"fallback-region",
-		"us-ashburn-1",
-		"Fallback OCI region to try when primary is out of capacity",
+		[]string{"us-ashburn-1"},
+		"Fallback OCI region to try when primary is out of capacity. Repeat for multiple fallback regions, tried in order.",
 	)
-	flags.StringVar(
-		&args.fallbackAvailabilityDomain,
+	flags.StringArrayVar(
+		&args.fallbackAvailabilityDomains,
 		"fallback-availability-domain",
-		"bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3",
-		"Comma-separated list of Availability Domains to try in order in the fallback region",
+		[]string{"bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3"},
+		"Comma-separated list of Availability Domains for the matching --fallback-region occurrence. Repeat per fallback region.",
 	)
-	flags.StringVar(
-		&args.fallbackSubnetId,
+	flags.StringArrayVar(
+		&args.fallbackSubnetIds,
 		"fallback-subnet-id",
-		"ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q",
-		"Subnet ID for the fallback region",
+		[]string{"ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q"},
+		"Subnet ID for the matching --fallback-region occurrence. Repeat per fallback region.",
 	)
 }

--- a/ci/cloudrunners/oci/main.go
+++ b/ci/cloudrunners/oci/main.go
@@ -46,17 +46,28 @@ var args struct {
 	bootVolumeSizeGB   int64
 	runEnv             string
 	preemptible        bool
+	preemptionQueue    string
 
 	fallbackRegion             string
 	fallbackAvailabilityDomain string
 	fallbackSubnetId           string
 }
 
+// exitCodePreempted is the sentinel exit code the launcher uses when the
+// instance was reclaimed by OCI mid-job. The preemption-rerun CronJob in
+// ci/cluster/oci/hacks/ keys off this value; keep them in sync.
+const exitCodePreempted = 79
+
+var errPreempted = errors.New("instance preempted")
+
 func main() {
 	log.SetFlags(log.Flags() | log.Lshortfile)
 
 	if err := Cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		if errors.Is(err, errPreempted) {
+			os.Exit(exitCodePreempted)
+		}
 		os.Exit(1)
 	}
 
@@ -206,6 +217,14 @@ func run(cmd *cobra.Command, argv []string) error {
 					(state == core.InstanceLifecycleStateTerminating || state == core.InstanceLifecycleStateTerminated) {
 					log.Printf("INSTANCE PREEMPTED: region=%s ad=%s shape=%s state=%s: instance was reclaimed by OCI while the job was running",
 						region.Region, region.AvailabilityDomain, shape, state)
+					if args.preemptionQueue != "" {
+						if reportErr := reportPreemption(context.Background(), args.preemptionQueue); reportErr != nil {
+							log.Printf("failed to record preemption for auto-rerun: %v", reportErr)
+						} else {
+							log.Printf("preemption recorded in %s for auto-rerun", args.preemptionQueue)
+						}
+					}
+					err = fmt.Errorf("%w (region=%s ad=%s shape=%s): %w", errPreempted, region.Region, region.AvailabilityDomain, shape, err)
 				}
 			}
 			return err
@@ -434,6 +453,12 @@ func init() {
 		"preemptible",
 		true,
 		"Launch preemptible (spot) instances for lower cost. Instance may be reclaimed by OCI at any time.",
+	)
+	flags.StringVar(
+		&args.preemptionQueue,
+		"preemption-queue-configmap",
+		"preemption-rerun-queue",
+		"ConfigMap (in this pod's namespace) recording preempted jobs for auto-rerun. Empty disables reporting.",
 	)
 	flags.Int64Var(
 		&args.bootVolumeSizeGB,

--- a/ci/cloudrunners/oci/pkg/oci/ephemeralmachine.go
+++ b/ci/cloudrunners/oci/pkg/oci/ephemeralmachine.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
 	"k8s.io/klog/v2"
 )
 
@@ -58,7 +58,7 @@ func (m *EphemeralMachine) WaitForInstanceReady(ctx context.Context) error {
 		if err != nil {
 			// Handle rate limiting (429)
 			if svcErr, ok := common.IsServiceError(err); ok && svcErr.GetHTTPStatusCode() == 429 {
-				log.Info("rate limited by OCI API, retrying in 20 seconds","instanceID", m.instanceID)
+				log.Info("rate limited by OCI API, retrying in 20 seconds", "instanceID", m.instanceID)
 				time.Sleep(20 * time.Second)
 				continue
 			}
@@ -105,6 +105,16 @@ func (m *EphemeralMachine) WaitForInstanceReady(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (m *EphemeralMachine) LifecycleState(ctx context.Context) (core.InstanceLifecycleStateEnum, error) {
+	getInstanceResponse, err := m.computeClient.GetInstance(ctx, core.GetInstanceRequest{
+		InstanceId: &m.instanceID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("reading instance state: %w", err)
+	}
+	return getInstanceResponse.Instance.LifecycleState, nil
 }
 
 func (m *EphemeralMachine) Close() error {

--- a/ci/cloudrunners/oci/preemption.go
+++ b/ci/cloudrunners/oci/preemption.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const serviceAccountDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+type ephemeralRunner struct {
+	Status struct {
+		JobRepositoryName string `json:"jobRepositoryName"`
+		WorkflowRunID     int64  `json:"workflowRunId"`
+	} `json:"status"`
+}
+
+// reportPreemption records the preempted job in the rerun queue ConfigMap so
+// the preemption-rerun CronJob (ci/cluster/oci/hacks/) can re-run it once the
+// workflow run completes. It reads the job's repository and run ID from this
+// pod's own EphemeralRunner, whose name equals the pod name.
+func reportPreemption(ctx context.Context, queueConfigMap string) error {
+	token, err := os.ReadFile(serviceAccountDir + "/token")
+	if err != nil {
+		return fmt.Errorf("reading serviceaccount token: %w", err)
+	}
+	namespace, err := os.ReadFile(serviceAccountDir + "/namespace")
+	if err != nil {
+		return fmt.Errorf("reading serviceaccount namespace: %w", err)
+	}
+	caCert, err := os.ReadFile(serviceAccountDir + "/ca.crt")
+	if err != nil {
+		return fmt.Errorf("reading serviceaccount ca.crt: %w", err)
+	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caCert) {
+		return fmt.Errorf("parsing serviceaccount ca.crt")
+	}
+
+	podName, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("reading pod hostname: %w", err)
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: caPool},
+		},
+	}
+	apiServer := fmt.Sprintf("https://%s:%s",
+		os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
+	ns := strings.TrimSpace(string(namespace))
+	bearer := "Bearer " + strings.TrimSpace(string(token))
+
+	runnerURL := fmt.Sprintf("%s/apis/actions.github.com/v1alpha1/namespaces/%s/ephemeralrunners/%s",
+		apiServer, ns, podName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, runnerURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", bearer)
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("getting ephemeralrunner %s: %w", podName, err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("getting ephemeralrunner %s: HTTP %d: %s", podName, resp.StatusCode, body)
+	}
+
+	var runner ephemeralRunner
+	if err := json.Unmarshal(body, &runner); err != nil {
+		return fmt.Errorf("parsing ephemeralrunner %s: %w", podName, err)
+	}
+	if runner.Status.WorkflowRunID == 0 || runner.Status.JobRepositoryName == "" {
+		return fmt.Errorf("ephemeralrunner %s has no job info (workflowRunId=%d, jobRepositoryName=%q)",
+			podName, runner.Status.WorkflowRunID, runner.Status.JobRepositoryName)
+	}
+
+	entry, err := json.Marshal(map[string]any{
+		"repo":       runner.Status.JobRepositoryName,
+		"run_id":     runner.Status.WorkflowRunID,
+		"first_seen": time.Now().Unix(),
+	})
+	if err != nil {
+		return err
+	}
+	patch, err := json.Marshal(map[string]any{
+		"data": map[string]string{
+			fmt.Sprintf("run-%d", runner.Status.WorkflowRunID): string(entry),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	queueURL := fmt.Sprintf("%s/api/v1/namespaces/%s/configmaps/%s", apiServer, ns, queueConfigMap)
+	req, err = http.NewRequestWithContext(ctx, http.MethodPatch, queueURL, bytes.NewReader(patch))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", bearer)
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+	resp, err = client.Do(req)
+	if err != nil {
+		return fmt.Errorf("patching configmap %s: %w", queueConfigMap, err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("patching configmap %s: HTTP %d: %s", queueConfigMap, resp.StatusCode, body)
+	}
+
+	return nil
+}

--- a/ci/cloudrunners/oci/preemption.go
+++ b/ci/cloudrunners/oci/preemption.go
@@ -53,7 +53,10 @@ func reportPreemption(ctx context.Context, queueConfigMap string) error {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: caPool},
+			TLSClientConfig: &tls.Config{
+				RootCAs:    caPool,
+				MinVersion: tls.VersionTLS13,
+			},
 		},
 	}
 	apiServer := fmt.Sprintf("https://%s:%s",

--- a/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
+++ b/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
@@ -1,0 +1,176 @@
+---
+# Queue of preempted jobs awaiting rerun. Entries are written by the
+# gha-cloudrunner launcher (--preemption-queue-configmap) and consumed by the
+# preemption-rerun CronJob below. Keys are "run-<workflowRunId>", values are
+# JSON: {"repo":"owner/repo","run_id":<id>,"first_seen":<epoch>}.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: preemption-rerun-queue
+  namespace: arc-systems
+---
+# Lets the launcher pods (which run with the ARC "no permission" service
+# accounts) read their own EphemeralRunner and record preempted jobs in the
+# queue. Bound to all service accounts in arc-systems because each runner
+# scale set gets its own generated service account.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: preemption-reporter
+  namespace: arc-systems
+rules:
+  - apiGroups: ["actions.github.com"]
+    resources: ["ephemeralrunners"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["preemption-rerun-queue"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: preemption-reporter
+  namespace: arc-systems
+subjects:
+  - kind: Group
+    name: system:serviceaccounts:arc-systems
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: preemption-reporter
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: preemption-rerunner
+  namespace: arc-systems
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: preemption-rerun
+  namespace: arc-systems
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["preemption-rerun-queue"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: preemption-rerun
+  namespace: arc-systems
+subjects:
+  - kind: ServiceAccount
+    name: preemption-rerunner
+    namespace: arc-systems
+roleRef:
+  kind: Role
+  name: preemption-rerun
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: preemption-rerun
+  namespace: arc-systems
+spec:
+  schedule: "*/3 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: preemption-rerunner
+          containers:
+          - name: rerun
+            image: docker.io/alpine/k8s:1.32.10
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: DRY_RUN
+              value: "false"
+            - name: MAX_ATTEMPTS
+              value: "3"
+            - name: STALE_SECONDS
+              value: "86400"
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-arc-secret
+                  key: github_token
+            command:
+            - /bin/bash
+            args:
+            - -c
+            - |
+              set -uo pipefail
+              NS=arc-systems
+              QUEUE=preemption-rerun-queue
+              AUTH=()
+              [ -n "${GITHUB_TOKEN:-}" ] && AUTH=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+
+              drop() {
+                kubectl -n "${NS}" patch configmap "${QUEUE}" --type=json \
+                  -p "[{\"op\":\"remove\",\"path\":\"/data/$1\"}]" >/dev/null
+                echo "dequeued $1: $2"
+              }
+
+              now=$(date +%s)
+              entries=$(kubectl -n "${NS}" get configmap "${QUEUE}" -o json | jq -r '.data // {} | to_entries[] | @base64')
+              [ -z "${entries}" ] && { echo "queue empty"; exit 0; }
+
+              for e in ${entries}; do
+                key=$(echo "${e}" | base64 -d | jq -r '.key')
+                val=$(echo "${e}" | base64 -d | jq -r '.value')
+                repo=$(echo "${val}" | jq -r '.repo')
+                run_id=$(echo "${val}" | jq -r '.run_id')
+                first_seen=$(echo "${val}" | jq -r '.first_seen')
+                age=$(( now - first_seen ))
+
+                run=$(curl -sf "${AUTH[@]}" -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/${repo}/actions/runs/${run_id}")
+                if [ -z "${run}" ]; then
+                  echo "could not fetch ${repo} run ${run_id} (age ${age}s)"
+                  [ "${age}" -gt "${STALE_SECONDS}" ] && drop "${key}" "stale, run unfetchable"
+                  continue
+                fi
+
+                status=$(echo "${run}" | jq -r '.status')
+                conclusion=$(echo "${run}" | jq -r '.conclusion')
+                attempt=$(echo "${run}" | jq -r '.run_attempt')
+
+                if [ "${status}" != "completed" ]; then
+                  if [ "${age}" -gt "${STALE_SECONDS}" ]; then
+                    drop "${key}" "stale, still ${status} after ${age}s"
+                  else
+                    echo "keeping ${key}: run ${status}, waiting for completion"
+                  fi
+                  continue
+                fi
+
+                if [ "${conclusion}" = "failure" ] && [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
+                  if [ "${DRY_RUN}" = "true" ]; then
+                    drop "${key}" "DRY_RUN: would rerun failed jobs of ${repo} run ${run_id} (attempt ${attempt})"
+                  else
+                    if curl -sf -X POST "${AUTH[@]}" -H "Accept: application/vnd.github+json" \
+                      "https://api.github.com/repos/${repo}/actions/runs/${run_id}/rerun-failed-jobs" >/dev/null; then
+                      drop "${key}" "rerun triggered for ${repo} run ${run_id} (was attempt ${attempt})"
+                    else
+                      echo "rerun failed for ${repo} run ${run_id}, keeping ${key}"
+                      [ "${age}" -gt "${STALE_SECONDS}" ] && drop "${key}" "stale, rerun kept failing"
+                    fi
+                  fi
+                else
+                  drop "${key}" "no rerun: conclusion=${conclusion} attempt=${attempt}"
+                fi
+              done
+            resources:
+              limits:
+                cpu: 500m
+                memory: 200Mi
+          restartPolicy: Never

--- a/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
+++ b/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
@@ -87,11 +87,25 @@ spec:
       template:
         spec:
           serviceAccountName: preemption-rerunner
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: rerun
             image: docker.io/alpine/k8s:1.32.10
             imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
             env:
+            - name: HOME
+              value: /tmp
             - name: DRY_RUN
               value: "false"
             - name: MAX_ATTEMPTS
@@ -173,4 +187,10 @@ spec:
               limits:
                 cpu: 500m
                 memory: 200Mi
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          - name: tmp
+            emptyDir: {}
           restartPolicy: Never

--- a/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
+++ b/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
@@ -9,10 +9,18 @@ metadata:
   name: preemption-rerun-queue
   namespace: arc-systems
 ---
-# Lets the launcher pods (which run with the ARC "no permission" service
-# accounts) read their own EphemeralRunner and record preempted jobs in the
-# queue. Bound to all service accounts in arc-systems because each runner
-# scale set gets its own generated service account.
+# Shared identity for the vm-runner launcher pods (set as
+# serviceAccountName in each vm-runners AutoscalingRunnerSet template),
+# so the reporting grant below is scoped to launcher pods only rather
+# than every service account in the namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloudrunner-launcher
+  namespace: arc-systems
+---
+# Lets the launcher pods read their own EphemeralRunner and record
+# preempted jobs in the queue.
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -33,9 +41,9 @@ metadata:
   name: preemption-reporter
   namespace: arc-systems
 subjects:
-  - kind: Group
-    name: system:serviceaccounts:arc-systems
-    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: cloudrunner-launcher
+    namespace: arc-systems
 roleRef:
   kind: Role
   name: preemption-reporter

--- a/ci/cluster/oci/vm-runners/16cpu-64gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/16cpu-64gb-arm64/install.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-16cpu-64gb-arm64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/16cpu-64gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/16cpu-64gb-arm64/install.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/16cpu-64gb/install.yaml
+++ b/ci/cluster/oci/vm-runners/16cpu-64gb/install.yaml
@@ -309,6 +309,9 @@ spec:
         - --fallback-region=us-ashburn-1
         - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
+        - --fallback-region=us-chicago-1
+        - --fallback-availability-domain=bzBe:US-CHICAGO-1-AD-1,bzBe:US-CHICAGO-1-AD-2,bzBe:US-CHICAGO-1-AD-3
+        - --fallback-subnet-id=ocid1.subnet.oc1.us-chicago-1.aaaaaaaas4g2hefjefsztbnmeorimlvceikt4mxel26f4yihuvuixn3hw5uq
         env:
         - name: OCI_CONFIG_FILE
           value: /etc/oci/config
@@ -325,7 +328,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-16cpu-64gb-x86-64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/16cpu-64gb/install.yaml
+++ b/ci/cluster/oci/vm-runners/16cpu-64gb/install.yaml
@@ -299,7 +299,7 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=16.0
         - --shape-memory-in-gbs=64.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/24cpu-96gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/24cpu-96gb-arm64/install.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-24cpu-96gb-arm64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/24cpu-96gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/24cpu-96gb-arm64/install.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/2cpu-8gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/2cpu-8gb-arm64/install.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-2cpu-8gb-arm64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/2cpu-8gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/2cpu-8gb-arm64/install.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/2cpu-8gb/install.yaml
+++ b/ci/cluster/oci/vm-runners/2cpu-8gb/install.yaml
@@ -299,7 +299,7 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=2.0
         - --shape-memory-in-gbs=8.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/2cpu-8gb/install.yaml
+++ b/ci/cluster/oci/vm-runners/2cpu-8gb/install.yaml
@@ -309,6 +309,9 @@ spec:
         - --fallback-region=us-ashburn-1
         - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
+        - --fallback-region=us-chicago-1
+        - --fallback-availability-domain=bzBe:US-CHICAGO-1-AD-1,bzBe:US-CHICAGO-1-AD-2,bzBe:US-CHICAGO-1-AD-3
+        - --fallback-subnet-id=ocid1.subnet.oc1.us-chicago-1.aaaaaaaas4g2hefjefsztbnmeorimlvceikt4mxel26f4yihuvuixn3hw5uq
         env:
         - name: OCI_CONFIG_FILE
           value: /etc/oci/config
@@ -325,7 +328,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-2cpu-8gb-x86-64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/32cpu-128gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/32cpu-128gb-arm64/install.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-32cpu-128gb-arm64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/32cpu-128gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/32cpu-128gb-arm64/install.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/4cpu-16gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/4cpu-16gb-arm64/install.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-4cpu-16gb-arm64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/4cpu-16gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/4cpu-16gb-arm64/install.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/8cpu-32gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/8cpu-32gb-arm64/install.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/8cpu-32gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/8cpu-32gb-arm64/install.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: oracle-vm-8cpu-32gb-arm64-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-arm.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-16-64-arm-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-arm.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-x86.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-x86.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-16-64-x86-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-x86.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-x86.yaml
@@ -299,7 +299,7 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=16.0
         - --shape-memory-in-gbs=64.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-arm.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-2-8-arm-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-arm.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-x86.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-x86.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-2-8-x86-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-x86.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-x86.yaml
@@ -299,7 +299,7 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=2.0
         - --shape-memory-in-gbs=8.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-24-96-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-24-96-arm.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-24-96-arm-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-24-96-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-24-96-arm.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-32-128-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-32-128-arm.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-32-128-arm-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-32-128-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-32-128-arm.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-4-16-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-4-16-arm.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-4-16-arm-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-4-16-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-4-16-arm.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-8-32-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-8-32-arm.yaml
@@ -325,7 +325,7 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 999
-      serviceAccountName: cncf-ubuntu-8-32-arm-gha-rs-no-permission
+      serviceAccountName: cloudrunner-launcher
       volumes:
       - name: oci-config
         secret:

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-8-32-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-8-32-arm.yaml
@@ -307,7 +307,7 @@ spec:
         - --availability-domain=bzBe:US-SANJOSE-1-AD-1
         - --subnet-id=ocid1.subnet.oc1.us-sanjose-1.aaaaaaaahgdslvujnywu3hvhqbvgz23souseseozvypng7ehnxgcotislubq
         - --fallback-region=us-phoenix-1
-        - --fallback-availability-domain=bzBe:PHX-AD-3
+        - --fallback-availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --fallback-subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-32-128-x86.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-32-128-x86.yaml
@@ -299,15 +299,15 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=32.0
         - --shape-memory-in-gbs=128.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-chicago-1
-        - --availability-domain=bzBe:US-CHICAGO-1-AD-3
+        - --availability-domain=bzBe:US-CHICAGO-1-AD-3,bzBe:US-CHICAGO-1-AD-1,bzBe:US-CHICAGO-1-AD-2
         - --subnet-id=ocid1.subnet.oc1.us-chicago-1.aaaaaaaas4g2hefjefsztbnmeorimlvceikt4mxel26f4yihuvuixn3hw5uq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-4-16-x86.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-4-16-x86.yaml
@@ -299,15 +299,15 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=4.0
         - --shape-memory-in-gbs=16.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-chicago-1
-        - --availability-domain=bzBe:US-CHICAGO-1-AD-3
+        - --availability-domain=bzBe:US-CHICAGO-1-AD-3,bzBe:US-CHICAGO-1-AD-1,bzBe:US-CHICAGO-1-AD-2
         - --subnet-id=ocid1.subnet.oc1.us-chicago-1.aaaaaaaas4g2hefjefsztbnmeorimlvceikt4mxel26f4yihuvuixn3hw5uq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-32cpu-128gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-32cpu-128gb-x86-64.yaml
@@ -299,15 +299,15 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=32.0
         - --shape-memory-in-gbs=128.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-chicago-1
-        - --availability-domain=bzBe:US-CHICAGO-1-AD-3
+        - --availability-domain=bzBe:US-CHICAGO-1-AD-3,bzBe:US-CHICAGO-1-AD-1,bzBe:US-CHICAGO-1-AD-2
         - --subnet-id=ocid1.subnet.oc1.us-chicago-1.aaaaaaaas4g2hefjefsztbnmeorimlvceikt4mxel26f4yihuvuixn3hw5uq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-4cpu-16gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-4cpu-16gb-x86-64.yaml
@@ -299,15 +299,15 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=4.0
         - --shape-memory-in-gbs=16.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-chicago-1
-        - --availability-domain=bzBe:US-CHICAGO-1-AD-3
+        - --availability-domain=bzBe:US-CHICAGO-1-AD-3,bzBe:US-CHICAGO-1-AD-1,bzBe:US-CHICAGO-1-AD-2
         - --subnet-id=ocid1.subnet.oc1.us-chicago-1.aaaaaaaas4g2hefjefsztbnmeorimlvceikt4mxel26f4yihuvuixn3hw5uq
         - --fallback-region=us-ashburn-1
-        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1
+        - --fallback-availability-domain=bzBe:US-ASHBURN-AD-1,bzBe:US-ASHBURN-AD-2,bzBe:US-ASHBURN-AD-3
         - --fallback-subnet-id=ocid1.subnet.oc1.iad.aaaaaaaagygdzd4xgbz4xhqhvnbxnoemhjd5ick7vodx4ghk4kg6a6c4xh5q
         env:
         - name: OCI_CONFIG_FILE

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-24-96-x86.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-24-96-x86.yaml
@@ -299,12 +299,12 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=24.0
         - --shape-memory-in-gbs=96.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-phoenix-1
-        - --availability-domain=bzBe:PHX-AD-3
+        - --availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         - --fallback-region=us-sanjose-1
         - --fallback-availability-domain=bzBe:US-SANJOSE-1-AD-1

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-8-32-x86.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-8-32-x86.yaml
@@ -299,12 +299,12 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=8.0
         - --shape-memory-in-gbs=32.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-phoenix-1
-        - --availability-domain=bzBe:PHX-AD-3
+        - --availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         - --fallback-region=us-sanjose-1
         - --fallback-availability-domain=bzBe:US-SANJOSE-1-AD-1

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-24cpu-96gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-24cpu-96gb-x86-64.yaml
@@ -299,12 +299,12 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=24.0
         - --shape-memory-in-gbs=96.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-phoenix-1
-        - --availability-domain=bzBe:PHX-AD-3
+        - --availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         - --fallback-region=us-sanjose-1
         - --fallback-availability-domain=bzBe:US-SANJOSE-1-AD-1

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-8cpu-32gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-8cpu-32gb-x86-64.yaml
@@ -299,12 +299,12 @@ spec:
         image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
         args:
         - --arch=amd64
-        - --shape=VM.Standard.E4.Flex,VM.Standard.E5.Flex
+        - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex
         - --shape-ocpus=8.0
         - --shape-memory-in-gbs=32.0
         - --compartment-id=ocid1.compartment.oc1..aaaaaaaa22icap66vxktktubjlhf6oxvfhev6n7udgje2chahyrtq65ga63a
         - --region=us-phoenix-1
-        - --availability-domain=bzBe:PHX-AD-3
+        - --availability-domain=bzBe:PHX-AD-3,bzBe:PHX-AD-1,bzBe:PHX-AD-2
         - --subnet-id=ocid1.subnet.oc1.phx.aaaaaaaabmyvcputzxzy5hrkezavo6m7efa7ap54ztyrj5nvupayqyuw4kja
         - --fallback-region=us-sanjose-1
         - --fallback-availability-domain=bzBe:US-SANJOSE-1-AD-1


### PR DESCRIPTION
## What

Since the preemptible rollout cut costs significantly, some jobs get reclaimed minutes after their VM starts and fail as `runner lost communication` with no retry. This PR attacks both the reclaim probability and the blast radius:

### Reduce reclaim probability
- **Prefer E5.Flex over E4.Flex** for preemptible x86 launches. E4 is the oldest, most capacity-constrained fleet; preemptible instances there get reclaimed the moment on-demand needs the space. E4 stays as fallback.
- **Multi-AD failover**: `--availability-domain`/`--fallback-availability-domain` now accept comma-separated lists. Fallback launches spread across all 3 Ashburn ADs; Phoenix/Chicago pools spread across their 3 ADs (subnets are regional, so existing subnet IDs cover all ADs).

### Fix a related sizing bug
- **arm64 pools were silently half-size**: the vCPU→OCPU halving assumed SMT, but Ampere A1 has 1 vCPU per OCPU. `oracle-16cpu-*-arm64` was delivering 8 vCPUs. Now shape-aware.

### Auto re-run preempted jobs
- On preemption, the launcher reads `{repo, workflowRunId}` from its own EphemeralRunner and records it in the `arc-systems/preemption-rerun-queue` ConfigMap (plain HTTPS with the SA token, no client-go), then exits with sentinel code 79.
- A `preemption-rerun` CronJob (`*/3`, `Forbid`) processes the queue: when a run completes as `failure` and is under 3 attempts, it calls `rerun-failed-jobs` (existing ARC token) and dequeues. Entries for in-progress runs wait; stale entries (24h) are evicted.
- Launcher self-reporting (instead of a cron scanning Failed EphemeralRunners) sidesteps ARC's pod-retry/ER-deletion behavior, which destroys failure evidence before a scanner could reliably see it.
- **Live from day one** (`DRY_RUN=false`). Kill switch: set `DRY_RUN=true` for shadow mode (full processing/logging, no rerun API calls).

## Deploy ordering (post-merge)

The manifests pass comma-separated AD lists the currently-pinned `gha-cloudrunner` digest cannot parse:

1. Merge → `publish-cloudrunner-images` builds the new image
2. **Bump the image digest in the vm-runner manifests** (follow-up commit)
3. Let ArgoCD sync — if auto-sync is on, chi/phx pools fail launches between 1 and 2

Smoke test: first preemption should produce `INSTANCE PREEMPTED` in launcher logs → a `run-<id>` key in the queue CM → `rerun triggered` in CronJob logs within ~3 min of run completion.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean on `ci/cloudrunners`
- Manifest YAML validated + `kubectl apply --dry-run=client` clean; embedded script passes `bash -n`
- EphemeralRunner status fields (`jobRepositoryName`, `workflowRunId`) verified against ARC listener source: populated at job assignment, not cleared on failure