### PR TITLE
Update vm runners to the preemption-hardened cloudrunner image

### DIFF
--- a/ci/cluster/oci/vm-runners/16cpu-64gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/16cpu-64gb-arm64/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/16cpu-64gb/install.yaml
+++ b/ci/cluster/oci/vm-runners/16cpu-64gb/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oci/vm-runners/24cpu-96gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/24cpu-96gb-arm64/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/2cpu-8gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/2cpu-8gb-arm64/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/2cpu-8gb/install.yaml
+++ b/ci/cluster/oci/vm-runners/2cpu-8gb/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oci/vm-runners/32cpu-128gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/32cpu-128gb-arm64/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/4cpu-16gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/4cpu-16gb-arm64/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/8cpu-32gb-arm64/install.yaml
+++ b/ci/cluster/oci/vm-runners/8cpu-32gb-arm64/install.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-arm.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-x86.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-16-64-x86.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-arm.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-x86.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-2-8-x86.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-24-96-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-24-96-arm.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-32-128-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-32-128-arm.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-4-16-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-4-16-arm.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/cncf-ubuntu-8-32-arm.yaml
+++ b/ci/cluster/oci/vm-runners/cncf-ubuntu-8-32-arm.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=VM.Standard.A1.Flex

--- a/ci/cluster/oci/vm-runners/gpu-a10-1/install.yaml
+++ b/ci/cluster/oci/vm-runners/gpu-a10-1/install.yaml
@@ -297,7 +297,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.GPU.A10.1

--- a/ci/cluster/oci/vm-runners/gpu-a10-2/install.yaml
+++ b/ci/cluster/oci/vm-runners/gpu-a10-2/install.yaml
@@ -297,7 +297,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.GPU.A10.2

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-32-128-x86.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-32-128-x86.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-4-16-x86.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-4-16-x86.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-bm-arm.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/cncf-ubuntu-bm-arm.yaml
@@ -297,7 +297,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=arm64
         - --shape=BM.Standard.A4.48

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-32cpu-128gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-32cpu-128gb-x86-64.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-4cpu-16gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-chi/manifests/vm-runners/oracle-vm-4cpu-16gb-x86-64.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-24-96-x86.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-24-96-x86.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-8-32-x86.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/cncf-ubuntu-8-32-x86.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-24cpu-96gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-24cpu-96gb-x86-64.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex

--- a/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-8cpu-32gb-x86-64.yaml
+++ b/ci/cluster/oke-gha-phx/manifests/vm-runners/oracle-vm-8cpu-32gb-x86-64.yaml
@@ -296,7 +296,7 @@ spec:
     spec:
       containers:
       - name: runner
-        image: ghcr.io/cncf/gha-cloudrunner@sha256:ea0562a06e529210c314c76460a0ab1ef782620f66d42176da636560c871be88
+        image: ghcr.io/cncf/gha-cloudrunner@sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5
         args:
         - --arch=amd64
         - --shape=VM.Standard.E5.Flex,VM.Standard.E4.Flex


### PR DESCRIPTION
Follow-up to #553 — revs `gha-cloudrunner` on all 27 vm-runner manifests to the image built from the merge commit:

`sha256:0ed9e6456f09c1b441c7ca2dca03680b00e3e130dd5d3563aceea08754cf75f5`

Built by [run 30425768196](https://github.com/cncf/automation/actions/runs/30425768196): all four `test-image` legs (amd64 preemptible E5/E4, arm64 preemptible A1, both GPU shapes on-demand) launched real OCI VMs successfully with this binary, and SLSA provenance was generated and verified.

**This unblocks the merged manifests**: the AD-list/multi-fallback args from #553 require this binary — chi/phx pools fail launches until this syncs. Merge promptly.

Also required before/with sync (from #553): `hacks/preemption-rerun-cj.yaml` must be applied so the `cloudrunner-launcher` ServiceAccount exists before runner pods reference it.