### PR TITLE
Fix preemption-rerun CronJob image tag

### DIFF
--- a/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
+++ b/ci/cluster/oci/hacks/preemption-rerun-cj.yaml
@@ -103,7 +103,7 @@ spec:
               type: RuntimeDefault
           containers:
           - name: rerun
-            image: docker.io/alpine/k8s:1.32.10
+            image: docker.io/alpine/k8s:1.36.2
             imagePullPolicy: IfNotPresent
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
The `preemption-rerun` CronJob from #553 is stuck in `ImagePullBackOff`: `alpine/k8s:1.32.10` doesn't exist (the repo's tags jump from 1.32.13 to 1.33+; 1.32.10 was never published — my mistake picking it). Bump to `alpine/k8s:1.36.2`, matching the cluster's Kubernetes version. The job only uses bash/kubectl/jq/curl, all present in every alpine/k8s tag.

Once synced, pods from the next 3-minute tick should pull and run; no other changes needed.