### PR TITLE
labeler: support ** glob patterns in filePath rules

### DIFF
--- a/utilities/labeler/go.mod
+++ b/utilities/labeler/go.mod
@@ -3,6 +3,7 @@ module labeler
 go 1.26.1
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/google/go-github/v55 v55.0.0
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/utilities/labeler/go.sum
+++ b/utilities/labeler/go.sum
@@ -1,5 +1,7 @@
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=

--- a/utilities/labeler/labeler.go
+++ b/utilities/labeler/labeler.go
@@ -7,10 +7,10 @@ import (
 	"log"
 	"net/http"
 	"path"
-	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/google/go-github/v55/github"
 	"golang.org/x/oauth2"
 	yaml "gopkg.in/yaml.v3"
@@ -150,7 +150,7 @@ func (l *Labeler) processFilePathRule(ctx context.Context, req *LabelRequest, ru
 	}
 
 	for _, file := range req.ChangedFiles {
-		matched, err := filepath.Match(rule.Spec.MatchPath, file)
+		matched, err := doublestar.Match(rule.Spec.MatchPath, file)
 		if err != nil {
 			return fmt.Errorf("error matching file path: %v", err)
 		}

--- a/utilities/labeler/labeler_test.go
+++ b/utilities/labeler/labeler_test.go
@@ -11,9 +11,9 @@ import (
 
 // MockGitHubClient implements GitHubClient for testing
 type MockGitHubClient struct {
-	Issues       map[int]*github.Issue
-	Labels       []*github.Label
-	IssueLabels  map[int][]*github.Label
+	Issues        map[int]*github.Issue
+	Labels        []*github.Label
+	IssueLabels   map[int][]*github.Label
 	CreatedLabels map[string]*github.Label
 	DeletedLabels []string
 	AppliedLabels map[int][]string
@@ -49,7 +49,7 @@ func (m *MockGitHubClient) AddLabelsToIssue(ctx context.Context, owner, repo str
 		m.AppliedLabels[number] = []string{}
 	}
 	m.AppliedLabels[number] = append(m.AppliedLabels[number], labels...)
-	
+
 	// Add to issue labels
 	for _, label := range labels {
 		labelObj := &github.Label{Name: &label}
@@ -63,7 +63,7 @@ func (m *MockGitHubClient) RemoveLabelForIssue(ctx context.Context, owner, repo 
 		m.RemovedLabels[number] = []string{}
 	}
 	m.RemovedLabels[number] = append(m.RemovedLabels[number], label)
-	
+
 	// Remove from issue labels
 	for i, lbl := range m.IssueLabels[number] {
 		if lbl.GetName() == label {
@@ -96,7 +96,7 @@ func (m *MockGitHubClient) EditLabel(ctx context.Context, owner, repo, name stri
 
 func (m *MockGitHubClient) DeleteLabel(ctx context.Context, owner, repo, name string) (*github.Response, error) {
 	m.DeletedLabels = append(m.DeletedLabels, name)
-	
+
 	// Remove from labels
 	for i, lbl := range m.Labels {
 		if lbl.GetName() == name {
@@ -248,6 +248,64 @@ func TestLabeler_ProcessFilePathRule(t *testing.T) {
 	}
 }
 
+// TestLabeler_ProcessFilePathRule_DoubleStar verifies that "**" patterns match
+// files nested arbitrarily deep. filepath.Match treated "**" as a single "*"
+// (never crossing "/"), so before the switch to doublestar a pattern like
+// "ci/**" would not match "ci/cluster/oke-gha-chi/manifests/hacks/foo.yaml".
+func TestLabeler_ProcessFilePathRule_DoubleStar(t *testing.T) {
+	client := NewMockGitHubClient()
+	config := createTestConfig()
+	config.Labels = append(config.Labels, Label{Name: "area/ci", Color: "7057FF", Description: "CI/CD infrastructure and automation"})
+	config.Ruleset = []Rule{
+		{
+			Name: "area-ci",
+			Kind: "filePath",
+			Spec: RuleSpec{
+				MatchPath: "ci/**",
+			},
+			Actions: []Action{
+				{
+					Kind: "apply-label",
+					Spec: ActionSpec{Label: "area/ci"},
+				},
+			},
+		},
+	}
+	labeler := NewLabeler(client, config)
+
+	tests := []struct {
+		name        string
+		changedFile string
+		wantMatch   bool
+	}{
+		{"deeply nested file", "ci/cluster/oke-gha-chi/manifests/hacks/preemption-rerun-cj.yaml", true},
+		{"file directly under dir", "ci/foo.yaml", true},
+		{"file outside dir", "docs/ci-notes.md", false},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issueNumber := i + 1
+			req := &LabelRequest{
+				Owner:        "test-owner",
+				Repo:         "test-repo",
+				IssueNumber:  issueNumber,
+				ChangedFiles: []string{tt.changedFile},
+			}
+
+			if err := labeler.ProcessRequest(context.Background(), req); err != nil {
+				t.Fatalf("ProcessRequest failed: %v", err)
+			}
+
+			applied := sliceContains(client.AppliedLabels[issueNumber], "area/ci")
+			if applied != tt.wantMatch {
+				t.Errorf("file %q: applied=%v, want %v (labels: %v)",
+					tt.changedFile, applied, tt.wantMatch, client.AppliedLabels[issueNumber])
+			}
+		})
+	}
+}
+
 func TestLabeler_ProcessMatchRule_TriageCommand(t *testing.T) {
 	client := NewMockGitHubClient()
 	config := createTestConfig()
@@ -307,7 +365,7 @@ func TestLabeler_ProcessMatchRule_TagCommand(t *testing.T) {
 
 	// Check that both needs-triage and tag/developer-experience were applied
 	appliedLabels := client.AppliedLabels[1]
-	
+
 	if !sliceContains(appliedLabels, "tag/developer-experience") {
 		t.Errorf("Expected 'tag/developer-experience' label to be applied, got: %v", appliedLabels)
 	}
@@ -493,10 +551,10 @@ func TestLabeler_ProcessLabelRule_BracePattern(t *testing.T) {
 	}
 
 	cases := []struct {
-		name        string
-		existing    []*github.Label
-		wantApply   bool
-		wantRemove  bool
+		name       string
+		existing   []*github.Label
+		wantApply  bool
+		wantRemove bool
 	}{
 		{
 			name:       "no group label → needs-group applied",
@@ -704,7 +762,7 @@ func TestLabeler_ProcessMatchRule_InvalidArgument(t *testing.T) {
 	if !sliceContains(appliedLabels, "needs-triage") {
 		t.Errorf("Expected 'needs-triage' to be applied, got: %v", appliedLabels)
 	}
-	
+
 	// Should not contain any tag labels
 	for _, label := range appliedLabels {
 		if strings.HasPrefix(label, "tag/") {

--- a/utilities/labeler/labeler_test.go
+++ b/utilities/labeler/labeler_test.go
@@ -249,9 +249,9 @@ func TestLabeler_ProcessFilePathRule(t *testing.T) {
 }
 
 // TestLabeler_ProcessFilePathRule_DoubleStar verifies that "**" patterns match
-// files nested arbitrarily deep. filepath.Match treated "**" as a single "*"
-// (never crossing "/"), so before the switch to doublestar a pattern like
-// "ci/**" would not match "ci/cluster/oke-gha-chi/manifests/hacks/foo.yaml".
+// files nested arbitrarily deep. filepath.Match has no doublestar semantics, and
+// "*" (and therefore "**" when treated literally) never crosses "/", so before
+// the switch to doublestar a pattern like
 func TestLabeler_ProcessFilePathRule_DoubleStar(t *testing.T) {
 	client := NewMockGitHubClient()
 	config := createTestConfig()


### PR DESCRIPTION
`filePath` rules in the labeler never matched nested files when using `**` patterns. This PR switches path matching from Go's `filepath.Match` to `github.com/bmatcuk/doublestar/v4` so recursive globs work as intended.

## Problem

`filepath.Match` has no `**` support — `*` (and therefore `**`) never crosses a `/` separator. All `**` rules in `.github/labels.yaml` were affected (`area-ci`, `area-utilities`, `area-cloudrunners`, `area-ambassadors`, `area-kubestronaut`, `area-tests`).

For example, a PR touching `ci/cluster/oke-gha-chi/manifests/hacks/preemption-rerun-cj.yaml` did **not** receive the `area/ci` label, because `ci/**` only matched files directly under `ci/` (e.g. `ci/foo.yaml`).

## Changes

- `labeler.go`: use `doublestar.Match` instead of `filepath.Match` in `processFilePathRule`
- `go.mod` / `go.sum`: add `github.com/bmatcuk/doublestar/v4 v4.10.0`
- `labeler_test.go`: add `TestLabeler_ProcessFilePathRule_DoubleStar` covering deeply nested matches, direct-child matches, and non-matches
