### PR TITLE
Use emptyDir for the container runners for /work

### DIFF
--- a/ci/cluster/lke-gha-iad2/manifests/container-runners/cncf-c-ubuntu-2-8-x86.yaml
+++ b/ci/cluster/lke-gha-iad2/manifests/container-runners/cncf-c-ubuntu-2-8-x86.yaml
@@ -306,7 +306,7 @@ spec:
           value: unix:///var/run/docker.sock
         - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
           value: "120"
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: runner
         resources:
           limits:
@@ -409,7 +409,7 @@ spec:
         - /home/runner/tmpDir/
         command:
         - cp
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: init-dind-externals
         volumeMounts:
         - mountPath: /home/runner/tmpDir
@@ -433,26 +433,9 @@ spec:
         name: dind-sock
       - emptyDir: {}
         name: dind-externals
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 50Gi
-              storageClassName: linode-block-storage-wffc
+      - emptyDir:
+          sizeLimit: 50Gi
         name: work
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Gi
-              storageClassName: linode-block-storage-wffc
-        name: overlay
       tolerations:
       - key: "cncf.io/gha-runner"
         operator: "Exists"

--- a/ci/cluster/oci/runners/16cpu-64gb/install.yaml
+++ b/ci/cluster/oci/runners/16cpu-64gb/install.yaml
@@ -290,7 +290,6 @@ spec:
             3000.0,
             3600.0,
           ]
-
   listenerTemplate:
     spec:
       containers:
@@ -307,7 +306,7 @@ spec:
           value: unix:///var/run/docker.sock
         - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
           value: "120"
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: runner
         resources:
           limits:
@@ -388,7 +387,7 @@ spec:
         - -R
         - "1777"
         - /tmp
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: docker.io/library/busybox:1.38.0
         name: chowner
         securityContext:
           capabilities:
@@ -410,7 +409,7 @@ spec:
         - /home/runner/tmpDir/
         command:
         - cp
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: init-dind-externals
         volumeMounts:
         - mountPath: /home/runner/tmpDir
@@ -434,26 +433,9 @@ spec:
         name: dind-sock
       - emptyDir: {}
         name: dind-externals
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 50Gi
-              storageClassName: oci-bv
+      - emptyDir:
+          sizeLimit: 50Gi
         name: work
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Gi
-              storageClassName: oci-bv
-        name: overlay
       tolerations:
       - key: "cncf.io/gha-runner"
         operator: "Exists"

--- a/ci/cluster/oci/runners/2cpu-8gb/install.yaml
+++ b/ci/cluster/oci/runners/2cpu-8gb/install.yaml
@@ -306,7 +306,7 @@ spec:
           value: unix:///var/run/docker.sock
         - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
           value: "120"
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: runner
         resources:
           limits:
@@ -387,7 +387,7 @@ spec:
         - -R
         - "1777"
         - /tmp
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: docker.io/library/busybox:1.38.0
         name: chowner
         securityContext:
           capabilities:
@@ -409,7 +409,7 @@ spec:
         - /home/runner/tmpDir/
         command:
         - cp
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: init-dind-externals
         volumeMounts:
         - mountPath: /home/runner/tmpDir
@@ -433,26 +433,9 @@ spec:
         name: dind-sock
       - emptyDir: {}
         name: dind-externals
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 50Gi
-              storageClassName: oci-bv
+      - emptyDir:
+          sizeLimit: 50Gi
         name: work
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Gi
-              storageClassName: oci-bv
-        name: overlay
       tolerations:
       - key: "cncf.io/gha-runner"
         operator: "Exists"

--- a/ci/cluster/oci/runners/8cpu-32gb/install.yaml
+++ b/ci/cluster/oci/runners/8cpu-32gb/install.yaml
@@ -307,7 +307,7 @@ spec:
           value: unix:///var/run/docker.sock
         - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
           value: "120"
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: runner
         resources:
           limits:
@@ -388,7 +388,7 @@ spec:
         - -R
         - "1777"
         - /tmp
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: docker.io/library/busybox:1.38.0
         name: chowner
         securityContext:
           capabilities:
@@ -410,7 +410,7 @@ spec:
         - /home/runner/tmpDir/
         command:
         - cp
-        image: ghcr.io/cncf/external-gha-runner:noble@sha256:bc0f43cb4fd68714ccf8762716629026d5339d97dc49569d503c613c93bba6a5
+        image: ghcr.io/cncf/external-gha-runner:noble@sha256:072ec0c6b43e657d85db23adfc4f39b4737f2368bdfdacb6caa408d61fa372bd
         name: init-dind-externals
         volumeMounts:
         - mountPath: /home/runner/tmpDir
@@ -434,26 +434,9 @@ spec:
         name: dind-sock
       - emptyDir: {}
         name: dind-externals
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 50Gi
-              storageClassName: oci-bv
+      - emptyDir:
+          sizeLimit: 50Gi
         name: work
-      - ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Gi
-              storageClassName: oci-bv
-        name: overlay
       tolerations:
       - key: "cncf.io/gha-runner"
         operator: "Exists"

--- a/ci/iac/akamai/cluster/cluster.tf
+++ b/ci/iac/akamai/cluster/cluster.tf
@@ -11,7 +11,7 @@ resource "linode_lke_cluster" "github_runners" {
   region      = var.region
   tags        = local.common_tags
   vpc_id      = linode_vpc.main.id
-  subnet_id   = linode_vpc_subnet.cluster.id
+  # subnet_id   = linode_vpc_subnet.cluster.id
 
   control_plane {
     high_availability = true
@@ -28,7 +28,7 @@ resource "linode_lke_cluster" "github_runners" {
     type            = var.node_type
     count           = var.node_count
     disk_encryption = "enabled"
-    firewall_id     = linode_firewall.cluster.id
+    # firewall_id     = linode_firewall.cluster.id
 
     autoscaler {
       min = var.autoscaler_min

--- a/ci/iac/akamai/cluster/tfvars/lke-cncf-gha-iad2.tfvars
+++ b/ci/iac/akamai/cluster/tfvars/lke-cncf-gha-iad2.tfvars
@@ -1,5 +1,5 @@
 cluster_name        = "lke-cncf-gha-iad2"
-kubernetes_version  = "1.35"
+kubernetes_version  = "1.36"
 region              = "us-iad-2"
 node_count          = 3
 node_type           = "g8-dedicated-16-4"


### PR DESCRIPTION
Replaces `ephemeral-storage` requests/limits with an `emptyDir.sizeLimit` on the shared `work` volume for all container-based runner scale sets. Also includes a Kubernetes version update for the LKE cluster.

This changed the `work` PVC to `emptyDir`. It was 50GB, and the nodes on Akamai and Oracle do provide sufficient disk space. Also, ephemeral storage isn't reserved in advance, so we can assign a larger size.

> This change reduced the SBOM generation job from 3,5 hours to 35 minutes.
> https://github.com/cncf/sbom/actions/runs/31921990887

/kind chore
/status needs-review
/priority medium
