### PR TITLE
dot-project: expanded repo configs schema

### DIFF
--- a/utilities/dot-project/SCHEMA.md
+++ b/utilities/dot-project/SCHEMA.md
@@ -20,7 +20,7 @@ This document defines the schema for CNCF `.project` repository metadata files.
 | `project_lead` | string \| string[] | No | One or more primary contact GitHub handles or teams. Accepts a plain string (single lead, backward-compatible) or a YAML list (multiple leads) | Non-empty if present; `@` prefix is stripped; each entry can be a GitHub handle (e.g., `jdoe`) or a GitHub team (e.g., `org/team-name`) |
 | `slack_channels` | SlackChannel[] | No | One or more CNCF Slack channels | Each `name` must start with `#`; at most one entry may set `primary: true` |
 | `maturity_log` | MaturityEntry[] | Yes | Maturity phase history | At least one entry; chronological order |
-| `repositories` | string[] | Yes | Repository URLs | At least one valid HTTP(S) URL |
+| `repositories` | (string \| RepositoryEntry)[] | Yes | Repository URLs with optional metadata. Each entry can be a plain URL string (backward-compatible) or an object with `url` and optional `tags` | At least one entry; each must have a valid HTTP(S) URL |
 | `website` | string | No | Project website | Valid HTTP(S) URL if present |
 | `adopters` | PathRef | No | Link to ADOPTERS.md or adopters list | Path must be non-empty if present |
 | `artwork` | string | No | Artwork/logo URL | Valid HTTP(S) URL if present |
@@ -40,6 +40,28 @@ This document defines the schema for CNCF `.project` repository metadata files.
 | `phase` | string | Yes | Maturity phase | One of: `sandbox`, `incubating`, `graduated`, `archived` |
 | `date` | datetime | Yes | Date of phase transition | ISO 8601 format |
 | `issue` | string | Yes | TOC issue URL | Non-empty |
+
+### RepositoryEntry
+
+Each entry in the `repositories` list can be either a plain URL string or an object:
+
+| Field | Type | Required | Description | Constraints |
+|-------|------|----------|-------------|-------------|
+| `url` | string | Yes | Repository URL | Valid HTTP(S) URL |
+| `tags` | string[] | No | Labels/categories for grouping (e.g., `core`, `sig-apps`, `tooling`) | Each tag must be non-empty |
+| `primary` | boolean | No | Whether this is the main project repository | At most one entry per project may be `true` |
+
+Example:
+
+```yaml
+repositories:
+  - url: "https://github.com/helm/helm"
+    primary: true
+  - url: "https://github.com/helm/chart-testing"
+    tags: [tooling]
+  - url: "https://github.com/helm/helm-www"
+    tags: [docs]
+```
 
 ### SlackChannel
 

--- a/utilities/dot-project/audit.go
+++ b/utilities/dot-project/audit.go
@@ -82,7 +82,7 @@ func collectProjectURLs(project Project) []AuditCheck {
 
 	// Repositories
 	for i, repo := range project.Repositories {
-		checks = append(checks, AuditCheck{Field: fmt.Sprintf("repositories[%d]", i), URL: repo})
+		checks = append(checks, AuditCheck{Field: fmt.Sprintf("repositories[%d]", i), URL: repo.URL})
 	}
 
 	// Audit report URLs

--- a/utilities/dot-project/audit_test.go
+++ b/utilities/dot-project/audit_test.go
@@ -53,7 +53,7 @@ func TestAuditProject(t *testing.T) {
 
 	project := validBaseProject()
 	project.Website = server.URL + "/ok"
-	project.Repositories = []string{server.URL + "/repo"}
+	project.Repositories = []RepositoryEntry{{URL: server.URL + "/repo"}}
 	project.Artwork = server.URL + "/not-found"
 
 	result := AuditProject(project, server.Client())

--- a/utilities/dot-project/bootstrap_scaffold.go
+++ b/utilities/dot-project/bootstrap_scaffold.go
@@ -39,10 +39,12 @@ maturity_log:
     date: "{{ formatTime .AcceptedDate }}"
     {{ if .TOCIssueURL }}issue: "{{ .TOCIssueURL }}"{{ if isAutoDetected .Sources "toc_issue_url" }} # TODO: AUTO-DETECTED — please verify{{ end }}{{ else }}issue: "https://github.com/cncf/toc/issues/XXX" # TODO: Set TOC issue URL{{ end }}
 
-repositories:{{ if .Repositories }}{{ range .Repositories }}
-  - "{{ . }}"{{ end }}{{ else }}
+repositories:{{ if .Repositories }}{{ if isAutoDetected .Sources "primary_repo" }} # TODO: AUTO-DETECTED primary — please verify{{ end }}{{ range .Repositories }}
+  - url: "{{ . }}"{{ if isPrimaryRepo $.PrimaryRepo . }}
+    primary: true{{ end }}{{ end }}{{ else }}
   # TODO: Add repository URLs
-  - "https://github.com/{{ .GitHubOrg }}/{{ or .GitHubRepo .Slug }}"{{ end }}
+  - url: "https://github.com/{{ .GitHubOrg }}/{{ or .GitHubRepo .Slug }}"
+    primary: true{{ end }}
 {{ if .Website }}
 website: "{{ .Website }}"{{ else }}
 # TODO: Add project website
@@ -292,6 +294,9 @@ var templateFuncs = template.FuncMap{
 		}
 		_, ok := sources[key]
 		return ok
+	},
+	"isPrimaryRepo": func(primaryURL, repoURL string) bool {
+		return primaryURL != "" && strings.EqualFold(primaryURL, repoURL)
 	},
 }
 

--- a/utilities/dot-project/bootstrap_scaffold.go
+++ b/utilities/dot-project/bootstrap_scaffold.go
@@ -41,10 +41,12 @@ maturity_log:
 
 repositories:{{ if .Repositories }}{{ if isAutoDetected .Sources "primary_repo" }} # TODO: AUTO-DETECTED primary — please verify{{ end }}{{ range .Repositories }}
   - url: "{{ . }}"{{ if isPrimaryRepo $.PrimaryRepo . }}
-    primary: true{{ end }}{{ end }}{{ else }}
+    primary: true
+    # tags: [core, sig-apps] # Optional{{ end }}{{ end }}{{ else }}
   # TODO: Add repository URLs
   - url: "https://github.com/{{ .GitHubOrg }}/{{ or .GitHubRepo .Slug }}"
-    primary: true{{ end }}
+    primary: true
+    # tags: [core, sig-apps] # Optional{{ end }}
 {{ if .Website }}
 website: "{{ .Website }}"{{ else }}
 # TODO: Add project website

--- a/utilities/dot-project/bootstrap_sources.go
+++ b/utilities/dot-project/bootstrap_sources.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,7 +17,6 @@ import (
 const (
 	cloMonitorSearchPath    = "/api/projects/search"
 	defaultCLOMonitorURL    = "https://clomonitor.io"
-	defaultGitHubAPIURL     = "https://api.github.com"
 	defaultLandscapeYAMLURL = "https://raw.githubusercontent.com/cncf/landscape/master/landscape.yml"
 	landscapeLogoBaseURL    = "https://landscape.cncf.io/logos/"
 
@@ -254,6 +254,9 @@ type GitHubData struct {
 	// Slack channels discovered across the org
 	SlackChannels []string `json:"slack_channels,omitempty"`
 
+	// Pinned repositories on the GitHub org profile
+	PinnedRepos []string `json:"pinned_repos,omitempty"`
+
 	// Package managers detected from manifest files (registry → identifier)
 	PackageManagers map[string]string `json:"package_managers,omitempty"`
 }
@@ -277,7 +280,7 @@ func (g *GitHubData) addPackageManager(registry, identifier string) {
 // baseURL overrides the GitHub API URL (use "" for default).
 func fetchFromGitHub(org, repo, token string, client *http.Client, baseURL string) (*GitHubData, error) {
 	if baseURL == "" {
-		baseURL = defaultGitHubAPIURL
+		baseURL = DefaultGitHubAPIURL
 	}
 
 	result := &GitHubData{}
@@ -322,6 +325,11 @@ func fetchFromGitHub(org, repo, token string, client *http.Client, baseURL strin
 				result.Org = &orgData
 			}
 		}
+	}
+
+	// Fetch pinned repositories via GraphQL
+	if token != "" {
+		result.PinnedRepos = fetchPinnedRepos(org, token, client, baseURL)
 	}
 
 	// Fetch community profile (non-fatal if fails)
@@ -533,6 +541,111 @@ func FetchFromCLOMonitor(name string, client *http.Client, baseURL string) (*CLO
 	return fetchFromCLOMonitor(name, client, baseURL)
 }
 
+// fetchPinnedRepos fetches an organization's pinned repositories via the GitHub
+// GraphQL API. Returns the HTML URLs of pinned repos, or nil on any error.
+// Only includes public, non-archived repositories.
+func fetchPinnedRepos(org, token string, client *http.Client, baseURL string) []string {
+	graphqlURL := DefaultGitHubGraphQLURL
+	// For test servers, use the same base URL with /graphql path
+	if baseURL != "" && baseURL != DefaultGitHubAPIURL {
+		graphqlURL = strings.TrimRight(baseURL, "/") + "/graphql"
+	}
+
+	query, _ := json.Marshal(map[string]interface{}{
+		"query":     `query($org:String!){organization(login:$org){pinnedItems(first:6,types:REPOSITORY){nodes{... on Repository{url isArchived isPrivate}}}}}`,
+		"variables": map[string]string{"org": org},
+	})
+	req, err := http.NewRequest("POST", graphqlURL, bytes.NewReader(query))
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Authorization", "bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", bootstrapUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	var result struct {
+		Data struct {
+			Organization struct {
+				PinnedItems struct {
+					Nodes []struct {
+						URL        string `json:"url"`
+						IsArchived bool   `json:"isArchived"`
+						IsPrivate  bool   `json:"isPrivate"`
+					} `json:"nodes"`
+				} `json:"pinnedItems"`
+			} `json:"organization"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
+	}
+
+	var urls []string
+	for _, node := range result.Data.Organization.PinnedItems.Nodes {
+		if node.URL != "" && !node.IsArchived && !node.IsPrivate {
+			urls = append(urls, node.URL)
+		}
+	}
+	return urls
+}
+
+// detectPrimaryRepo determines which repository URL should be marked as primary.
+// Detection order: naming convention (org/slug match) → landscape repo_url → GitHub pinned repos (first).
+// Returns the primary URL and the detection source, or empty strings if none detected.
+func detectPrimaryRepo(repos []string, slug string, org string, landscape *LandscapeData, github *GitHubData) (primaryURL, source string) {
+	if len(repos) == 0 {
+		return "", ""
+	}
+
+	// Single repo is always primary
+	if len(repos) == 1 {
+		return repos[0], "single_repo"
+	}
+
+	// 1. Naming convention: repo URL ends with /{org}/{slug} or /{org}/{org}
+	slugSuffix := "/" + strings.ToLower(org) + "/" + strings.ToLower(slug)
+	orgSuffix := "/" + strings.ToLower(org) + "/" + strings.ToLower(org)
+	for _, u := range repos {
+		lower := strings.ToLower(strings.TrimSuffix(u, "/"))
+		if strings.HasSuffix(lower, slugSuffix) || strings.HasSuffix(lower, orgSuffix) {
+			return u, "naming_convention"
+		}
+	}
+
+	// 2. Landscape repo_url
+	if landscape != nil && landscape.RepoURL != "" {
+		for _, u := range repos {
+			if strings.EqualFold(u, landscape.RepoURL) {
+				return u, "landscape"
+			}
+		}
+	}
+
+	// 3. GitHub pinned repos (first pinned repo that appears in our list)
+	if github != nil && len(github.PinnedRepos) > 0 {
+		repoSet := make(map[string]string) // lowercase → original
+		for _, u := range repos {
+			repoSet[strings.ToLower(strings.TrimSuffix(u, "/"))] = u
+		}
+		for _, pinned := range github.PinnedRepos {
+			if orig, ok := repoSet[strings.ToLower(strings.TrimSuffix(pinned, "/"))]; ok {
+				return orig, "github_pinned"
+			}
+		}
+	}
+
+	return "", ""
+}
+
 // FetchFromGitHub is the exported wrapper for fetchFromGitHub.
 func FetchFromGitHub(org, repo, token string, client *http.Client, baseURL string) (*GitHubData, error) {
 	return fetchFromGitHub(org, repo, token, client, baseURL)
@@ -643,7 +756,7 @@ func fuzzyMatch(query string, candidates []string) (best string, score float64) 
 // Returns (hasDCO, hasCLA, error). Errors are non-fatal; returns (false, false, nil) on failure.
 func detectDCOCLA(org, repo, token string, client *http.Client, baseURL string) (bool, bool, error) {
 	if baseURL == "" {
-		baseURL = defaultGitHubAPIURL
+		baseURL = DefaultGitHubAPIURL
 	}
 
 	doGet := func(path string) (*http.Response, error) {
@@ -714,7 +827,7 @@ func detectDCOCLA(org, repo, token string, client *http.Client, baseURL string) 
 // Returns the best-match issue URL, or "" if none found.
 func SearchTOCIssues(projectName, orgName, token string, client *http.Client, baseURL string) (string, error) {
 	if baseURL == "" {
-		baseURL = defaultGitHubAPIURL
+		baseURL = DefaultGitHubAPIURL
 	}
 
 	// Search queries to try, in order of specificity
@@ -844,6 +957,12 @@ func mergeBootstrapData(slug string, landscape *LandscapeData, clomonitor *CLOMo
 	} else if github != nil && github.Repo != nil && github.Repo.HTMLURL != "" {
 		result.Repositories = []string{github.Repo.HTMLURL}
 		result.Sources["repositories"] = "github"
+	}
+
+	// Detect primary repository
+	if primaryURL, source := detectPrimaryRepo(result.Repositories, slug, result.GitHubOrg, landscape, github); primaryURL != "" {
+		result.PrimaryRepo = primaryURL
+		result.Sources["primary_repo"] = source
 	}
 
 	// Maturity: landscape > clomonitor

--- a/utilities/dot-project/bootstrap_sources.go
+++ b/utilities/dot-project/bootstrap_sources.go
@@ -552,7 +552,7 @@ func fetchPinnedRepos(org, token string, client *http.Client, baseURL string) []
 	}
 
 	query, _ := json.Marshal(map[string]interface{}{
-		"query":     `query($org:String!){organization(login:$org){pinnedItems(first:6,types:REPOSITORY){nodes{... on Repository{url isArchived isPrivate}}}}}`,
+		"query":     `query($org:String!){organization(login:$org){pinnedItems(first:6,types:REPOSITORY){nodes{... on Repository{url isArchived isPrivate isFork isDisabled isTemplate}}}}}`,
 		"variables": map[string]string{"org": org},
 	})
 	req, err := http.NewRequest("POST", graphqlURL, bytes.NewReader(query))
@@ -580,6 +580,9 @@ func fetchPinnedRepos(org, token string, client *http.Client, baseURL string) []
 						URL        string `json:"url"`
 						IsArchived bool   `json:"isArchived"`
 						IsPrivate  bool   `json:"isPrivate"`
+						IsFork     bool   `json:"isFork"`
+						IsDisabled bool   `json:"isDisabled"`
+						IsTemplate bool   `json:"isTemplate"`
 					} `json:"nodes"`
 				} `json:"pinnedItems"`
 			} `json:"organization"`
@@ -591,9 +594,10 @@ func fetchPinnedRepos(org, token string, client *http.Client, baseURL string) []
 
 	var urls []string
 	for _, node := range result.Data.Organization.PinnedItems.Nodes {
-		if node.URL != "" && !node.IsArchived && !node.IsPrivate {
-			urls = append(urls, node.URL)
+		if node.URL == "" || node.IsArchived || node.IsPrivate || node.IsFork || node.IsDisabled || node.IsTemplate {
+			continue
 		}
+		urls = append(urls, node.URL)
 	}
 	return urls
 }

--- a/utilities/dot-project/bootstrap_sources_test.go
+++ b/utilities/dot-project/bootstrap_sources_test.go
@@ -1312,3 +1312,87 @@ func TestDiscoverSecurityPolicy(t *testing.T) {
 		}
 	})
 }
+
+func TestDetectPrimaryRepo(t *testing.T) {
+	tests := []struct {
+		name      string
+		repos     []string
+		slug      string
+		org       string
+		landscape *LandscapeData
+		github    *GitHubData
+		wantURL   string
+		wantSrc   string
+	}{
+		{
+			name:    "single repo is always primary",
+			repos:   []string{"https://github.com/helm/helm"},
+			slug:    "helm",
+			org:     "helm",
+			wantURL: "https://github.com/helm/helm",
+			wantSrc: "single_repo",
+		},
+		{
+			name:    "naming convention: slug matches repo name",
+			repos:   []string{"https://github.com/falcosecurity/charts", "https://github.com/falcosecurity/falco"},
+			slug:    "falco",
+			org:     "falcosecurity",
+			wantURL: "https://github.com/falcosecurity/falco",
+			wantSrc: "naming_convention",
+		},
+		{
+			name:    "naming convention: org matches repo name",
+			repos:   []string{"https://github.com/helm/chart-testing", "https://github.com/helm/helm"},
+			slug:    "helm",
+			org:     "helm",
+			wantURL: "https://github.com/helm/helm",
+			wantSrc: "naming_convention",
+		},
+		{
+			name:      "landscape fallback when no naming match",
+			repos:     []string{"https://github.com/org/api", "https://github.com/org/core"},
+			slug:      "myproject",
+			org:       "org",
+			landscape: &LandscapeData{RepoURL: "https://github.com/org/core"},
+			wantURL:   "https://github.com/org/core",
+			wantSrc:   "landscape",
+		},
+		{
+			name:    "github pinned fallback",
+			repos:   []string{"https://github.com/org/api", "https://github.com/org/core"},
+			slug:    "myproject",
+			org:     "org",
+			github:  &GitHubData{PinnedRepos: []string{"https://github.com/org/core"}},
+			wantURL: "https://github.com/org/core",
+			wantSrc: "github_pinned",
+		},
+		{
+			name:    "no match returns empty",
+			repos:   []string{"https://github.com/org/api", "https://github.com/org/core"},
+			slug:    "myproject",
+			org:     "org",
+			wantURL: "",
+			wantSrc: "",
+		},
+		{
+			name:    "empty repos",
+			repos:   nil,
+			slug:    "test",
+			org:     "test",
+			wantURL: "",
+			wantSrc: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotSrc := detectPrimaryRepo(tt.repos, tt.slug, tt.org, tt.landscape, tt.github)
+			if gotURL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", gotURL, tt.wantURL)
+			}
+			if gotSrc != tt.wantSrc {
+				t.Errorf("source = %q, want %q", gotSrc, tt.wantSrc)
+			}
+		})
+	}
+}

--- a/utilities/dot-project/bootstrap_types.go
+++ b/utilities/dot-project/bootstrap_types.go
@@ -30,6 +30,7 @@ type BootstrapResult struct {
 	// URLs
 	Website      string            `json:"website,omitempty" yaml:"website,omitempty"`
 	Repositories []string          `json:"repositories,omitempty" yaml:"repositories,omitempty"`
+	PrimaryRepo  string            `json:"primary_repo,omitempty" yaml:"primary_repo,omitempty"` // Auto-detected primary repository URL
 	Artwork      string            `json:"artwork,omitempty" yaml:"artwork,omitempty"`
 	Social       map[string]string `json:"social,omitempty" yaml:"social,omitempty"`
 

--- a/utilities/dot-project/cmd/landscape-updater/main.go
+++ b/utilities/dot-project/cmd/landscape-updater/main.go
@@ -260,7 +260,7 @@ func matchAndUpdateItem(itemNode *yaml.Node, project *projects.Project, lines []
 	nameMatch := strings.EqualFold(nameNode.Value, project.Name)
 	repoMatch := false
 	for _, repo := range project.Repositories {
-		if strings.EqualFold(repoURLNode.Value, repo) {
+		if strings.EqualFold(repoURLNode.Value, repo.URL) {
 			repoMatch = true
 			break
 		}

--- a/utilities/dot-project/cmd/landscape-updater/main_test.go
+++ b/utilities/dot-project/cmd/landscape-updater/main_test.go
@@ -38,9 +38,7 @@ func TestUpdateLandscape(t *testing.T) {
 		Name:        "Kubernetes",
 		Description: "New description",
 		Website:     "https://kubernetes.io",
-		Repositories: []string{
-			"https://github.com/kubernetes/kubernetes",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/kubernetes/kubernetes"}},
 		Social: map[string]string{
 			"twitter":  "https://twitter.com/kubernetesio",
 			"slack":    "https://kubernetes.slack.com",
@@ -93,9 +91,7 @@ func TestNoChanges(t *testing.T) {
 		Name:        "MyProject",
 		Description: "My project description",
 		Website:     "https://myproject.io",
-		Repositories: []string{
-			"https://github.com/org/myproject",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/myproject"}},
 		Social: map[string]string{
 			"twitter": "https://twitter.com/myproject",
 		},
@@ -127,9 +123,7 @@ func TestUpdateExistingField(t *testing.T) {
 		Name:        "Proj",
 		Description: "Old desc",
 		Website:     "https://new.proj.io",
-		Repositories: []string{
-			"https://github.com/org/proj",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/proj"}},
 	}
 
 	newLines, updated := updateLandscape(root, project, lines)
@@ -166,9 +160,7 @@ func TestInsertNewField(t *testing.T) {
 		Name:        "Proj",
 		Description: "A new description",
 		Website:     "https://proj.io",
-		Repositories: []string{
-			"https://github.com/org/proj",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/proj"}},
 	}
 
 	newLines, updated := updateLandscape(root, project, lines)
@@ -206,9 +198,7 @@ func TestUpdateExtraField(t *testing.T) {
 	project := &projects.Project{
 		Name:    "Proj",
 		Website: "https://proj.io",
-		Repositories: []string{
-			"https://github.com/org/proj",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/proj"}},
 		Social: map[string]string{
 			"slack": "https://new-slack.com",
 		},
@@ -245,9 +235,7 @@ func TestInsertNewExtraField(t *testing.T) {
 	project := &projects.Project{
 		Name:    "Proj",
 		Website: "https://proj.io",
-		Repositories: []string{
-			"https://github.com/org/proj",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/proj"}},
 		Social: map[string]string{
 			"slack":    "https://slack.com",
 			"linkedin": "https://linkedin.com/proj",
@@ -287,9 +275,7 @@ func TestCreateExtraBlock(t *testing.T) {
 	project := &projects.Project{
 		Name:    "Proj",
 		Website: "https://proj.io",
-		Repositories: []string{
-			"https://github.com/org/proj",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/proj"}},
 		Social: map[string]string{
 			"slack": "https://slack.com/proj",
 		},
@@ -331,9 +317,7 @@ func TestMultiLineDescriptionReplacement(t *testing.T) {
 		Name:        "Proj",
 		Description: "Short new description",
 		Website:     "https://proj.io",
-		Repositories: []string{
-			"https://github.com/org/proj",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/proj"}},
 	}
 
 	newLines, updated := updateLandscape(root, project, lines)
@@ -383,9 +367,7 @@ func TestUnrelatedLinesUntouched(t *testing.T) {
 	project := &projects.Project{
 		Name:    "Target",
 		Website: "https://new.target.io",
-		Repositories: []string{
-			"https://github.com/org/target",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/org/target"}},
 	}
 
 	newLines, updated := updateLandscape(root, project, lines)
@@ -616,9 +598,7 @@ func TestPR4820_Meshery(t *testing.T) {
 		Name:        "Meshery",
 		Description: "Infrastructure by Design",
 		Website:     "https://meshery.io",
-		Repositories: []string{
-			"https://github.com/meshery/meshery",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/meshery/meshery"}},
 		Social: map[string]string{
 			"twitter": "https://twitter.com/mesheryio",
 		},
@@ -654,9 +634,7 @@ func TestPR4821_OpenEBS(t *testing.T) {
 		Name:        "OpenEBS",
 		Description: "Open Source Container Attached Storage, built using Cloud Native Architecture, simplifies running Stateful Applications on Kubernetes",
 		Website:     "https://www.openebs.io/",
-		Repositories: []string{
-			"https://github.com/openebs/openebs",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/openebs/openebs"}},
 		Social: map[string]string{
 			"twitter": "https://twitter.com/openebs",
 		},
@@ -687,9 +665,7 @@ func TestPR4822_OCM(t *testing.T) {
 		Name:        "Open Cluster Management",
 		Description: "Make working with many Kubernetes clusters super easy regardless of where they are deployed",
 		Website:     "https://open-cluster-management.io/",
-		Repositories: []string{
-			"https://github.com/open-cluster-management-io/ocm",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/open-cluster-management-io/ocm"}},
 		Social: map[string]string{
 			"twitter": "https://twitter.com/ocm_io",
 		},
@@ -720,9 +696,7 @@ func TestPR4823_kcp(t *testing.T) {
 		Name:        "kcp",
 		Description: "Kubernetes-like control planes for form-factors and use-cases beyond Kubernetes and container workloads.",
 		Website:     "https://kcp.io",
-		Repositories: []string{
-			"https://github.com/kcp-dev/kcp",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/kcp-dev/kcp"}},
 		Social: map[string]string{
 			"twitter": "https://twitter.com/kcp",
 		},
@@ -753,9 +727,7 @@ func TestPR4827_ORAS(t *testing.T) {
 		Name:        "ORAS",
 		Description: "ORAS is the tool for working with OCI Artifacts",
 		Website:     "https://oras.land/",
-		Repositories: []string{
-			"https://github.com/oras-project/oras",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/oras-project/oras"}},
 		Social: map[string]string{
 			"twitter": "https://twitter.com/orasproject",
 		},
@@ -786,9 +758,7 @@ func TestPR4829_k0s(t *testing.T) {
 		Name:        "k0s",
 		Description: "k0s is a CNCF-certified lightweight, Kubernetes distribution with zero dependencies and zero opinion.",
 		Website:     "https://k0sproject.io/",
-		Repositories: []string{
-			"https://github.com/k0sproject/k0s",
-		},
+		Repositories: []projects.RepositoryEntry{{URL: "https://github.com/k0sproject/k0s"}},
 		Social: map[string]string{
 			"twitter": "https://x.com/k0sproject",
 		},
@@ -867,32 +837,32 @@ func TestAllPRsNoNoiseRegression(t *testing.T) {
 	}{
 		{"Meshery", projects.Project{
 			Name: "Meshery", Description: "Infrastructure by Design",
-			Website: "https://meshery.io", Repositories: []string{"https://github.com/meshery/meshery"},
+			Website: "https://meshery.io", Repositories: []projects.RepositoryEntry{{URL: "https://github.com/meshery/meshery"}},
 			Social: map[string]string{"twitter": "https://twitter.com/mesheryio"},
 		}},
 		{"OpenEBS", projects.Project{
 			Name: "OpenEBS", Description: "Container Attached Storage",
-			Website: "https://www.openebs.io/", Repositories: []string{"https://github.com/openebs/openebs"},
+			Website: "https://www.openebs.io/", Repositories: []projects.RepositoryEntry{{URL: "https://github.com/openebs/openebs"}},
 			Social: map[string]string{"twitter": "https://twitter.com/openebs"},
 		}},
 		{"Open Cluster Management", projects.Project{
 			Name: "Open Cluster Management", Description: "Multi-cluster management",
-			Website: "https://open-cluster-management.io/", Repositories: []string{"https://github.com/open-cluster-management-io/ocm"},
+			Website: "https://open-cluster-management.io/", Repositories: []projects.RepositoryEntry{{URL: "https://github.com/open-cluster-management-io/ocm"}},
 			Social: map[string]string{"twitter": "https://twitter.com/ocm_io"},
 		}},
 		{"kcp", projects.Project{
 			Name: "kcp", Description: "Kubernetes-like control planes",
-			Website: "https://kcp.io", Repositories: []string{"https://github.com/kcp-dev/kcp"},
+			Website: "https://kcp.io", Repositories: []projects.RepositoryEntry{{URL: "https://github.com/kcp-dev/kcp"}},
 			Social: map[string]string{"twitter": "https://twitter.com/kcp"},
 		}},
 		{"ORAS", projects.Project{
 			Name: "ORAS", Description: "OCI Artifacts tool",
-			Website: "https://oras.land/", Repositories: []string{"https://github.com/oras-project/oras"},
+			Website: "https://oras.land/", Repositories: []projects.RepositoryEntry{{URL: "https://github.com/oras-project/oras"}},
 			Social: map[string]string{"twitter": "https://twitter.com/orasproject"},
 		}},
 		{"k0s", projects.Project{
 			Name: "k0s", Description: "Lightweight Kubernetes distribution",
-			Website: "https://k0sproject.io/", Repositories: []string{"https://github.com/k0sproject/k0s"},
+			Website: "https://k0sproject.io/", Repositories: []projects.RepositoryEntry{{URL: "https://github.com/k0sproject/k0s"}},
 			Social: map[string]string{"twitter": "https://x.com/k0sproject"},
 		}},
 	}

--- a/utilities/dot-project/cmd/migrate/main.go
+++ b/utilities/dot-project/cmd/migrate/main.go
@@ -68,8 +68,12 @@ func main() {
 
 	// Build project
 	repoList := strings.Split(*repos, ",")
-	for i := range repoList {
-		repoList[i] = strings.TrimSpace(repoList[i])
+	var repoEntries []projects.RepositoryEntry
+	for _, r := range repoList {
+		r = strings.TrimSpace(r)
+		if r != "" {
+			repoEntries = append(repoEntries, projects.RepositoryEntry{URL: r})
+		}
 	}
 
 	project := projects.Project{
@@ -77,7 +81,7 @@ func main() {
 		Slug:          *slug,
 		Name:          *name,
 		Description:   *description,
-		Repositories:  repoList,
+		Repositories:  repoEntries,
 		MaturityLog: []projects.MaturityEntry{
 			{
 				Phase: *maturity,

--- a/utilities/dot-project/governance_scan.go
+++ b/utilities/dot-project/governance_scan.go
@@ -25,7 +25,7 @@ const suggestionsFileName = "maintainer-suggestions.md"
 //     COMMUNITY files.
 func DiscoverGovernanceSuggestions(org, primaryRepo, token string, client *http.Client, baseURL string, csvHandles map[string]bool) ([]MaintainerSuggestion, []string) {
 	if baseURL == "" {
-		baseURL = defaultGitHubAPIURL
+		baseURL = DefaultGitHubAPIURL
 	}
 	doGet := func(path string) (*http.Response, error) {
 		req, err := http.NewRequest("GET", baseURL+path, nil)

--- a/utilities/dot-project/landscape.go
+++ b/utilities/dot-project/landscape.go
@@ -44,9 +44,9 @@ func ProjectToLandscapeEntry(project Project) LandscapeEntry {
 		Extra:       make(map[string]interface{}),
 	}
 
-	// Use first repository as repo_url
-	if len(project.Repositories) > 0 {
-		entry.RepoURL = project.Repositories[0]
+	// Use primary repository as repo_url
+	if repoURL := PrimaryRepositoryURL(project.Repositories); repoURL != "" {
+		entry.RepoURL = repoURL
 	}
 
 	// Get twitter URL from social

--- a/utilities/dot-project/landscape_format_test.go
+++ b/utilities/dot-project/landscape_format_test.go
@@ -96,7 +96,7 @@ artwork: "https://artwork.example.com/logo.svg"
 	if proj.Website != "https://test-proj.io" {
 		t.Errorf("expected website, got %q", proj.Website)
 	}
-	if len(proj.Repositories) != 1 || proj.Repositories[0] != "https://github.com/test/repo" {
+	if len(proj.Repositories) != 1 || proj.Repositories[0].URL != "https://github.com/test/repo" {
 		t.Errorf("unexpected repositories: %v", proj.Repositories)
 	}
 	if len(proj.MaturityLog) != 1 || proj.MaturityLog[0].Phase != "sandbox" {

--- a/utilities/dot-project/security_test.go
+++ b/utilities/dot-project/security_test.go
@@ -79,7 +79,7 @@ func TestSecurityContactValidation(t *testing.T) {
 						Issue: "https://github.com/cncf/toc/issues/123",
 					},
 				},
-				Repositories: []string{"https://github.com/test/repo"},
+				Repositories: []RepositoryEntry{{URL: "https://github.com/test/repo"}},
 				Security: &SecurityConfig{
 					Contact: tt.contact,
 				},

--- a/utilities/dot-project/social_test.go
+++ b/utilities/dot-project/social_test.go
@@ -16,7 +16,7 @@ func TestSocialValidation(t *testing.T) {
 				Issue: "https://github.com/cncf/toc/issues/123",
 			},
 		},
-		Repositories: []string{"https://github.com/test/repo"},
+		Repositories: []RepositoryEntry{{URL: "https://github.com/test/repo"}},
 		Social: map[string]string{
 			"twitter": "invalid-url",
 			"slack":   "https://slack.com", // Valid

--- a/utilities/dot-project/test_helpers_test.go
+++ b/utilities/dot-project/test_helpers_test.go
@@ -17,6 +17,6 @@ func validBaseProject() Project {
 				Issue: "https://github.com/cncf/toc/issues/123",
 			},
 		},
-		Repositories: []string{"https://github.com/test/repo"},
+		Repositories: []RepositoryEntry{{URL: "https://github.com/test/repo"}},
 	}
 }

--- a/utilities/dot-project/types.go
+++ b/utilities/dot-project/types.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -55,11 +56,103 @@ func (s StringOrSlice) MarshalYAML() (interface{}, error) {
 	}
 }
 
+// RepositoryEntry represents a project repository. It supports two YAML forms:
+//
+//	repositories:
+//	  - "https://github.com/org/repo"            # plain string (backward-compatible)
+//	  - url: "https://github.com/org/repo"       # expanded object with optional tags
+//	    tags: [core, sig-apps]
+type RepositoryEntry struct {
+	URL     string   `json:"url" yaml:"url"`
+	Tags    []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Primary bool     `json:"primary,omitempty" yaml:"primary,omitempty"`
+}
+
+// UnmarshalYAML allows a repository entry to be either a plain string or a mapping.
+func (r *RepositoryEntry) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		r.URL = value.Value
+		return nil
+	case yaml.MappingNode:
+		var aux struct {
+			URL     string   `yaml:"url"`
+			Tags    []string `yaml:"tags"`
+			Primary bool     `yaml:"primary"`
+		}
+		if err := value.Decode(&aux); err != nil {
+			return err
+		}
+		r.URL = aux.URL
+		r.Tags = aux.Tags
+		r.Primary = aux.Primary
+		return nil
+	default:
+		return fmt.Errorf("expected string or mapping for repository entry, got YAML node type %v", value.Tag)
+	}
+}
+
+// MarshalYAML always serializes a RepositoryEntry as a mapping with a url key
+// for consistency, even when there are no tags.
+func (r RepositoryEntry) MarshalYAML() (interface{}, error) {
+	return struct {
+		URL     string   `yaml:"url"`
+		Tags    []string `yaml:"tags,omitempty"`
+		Primary bool     `yaml:"primary,omitempty"`
+	}{URL: r.URL, Tags: r.Tags, Primary: r.Primary}, nil
+}
+
+// UnmarshalJSON allows a repository entry to be either a plain string or an object.
+func (r *RepositoryEntry) UnmarshalJSON(data []byte) error {
+	// Try string first
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		r.URL = s
+		return nil
+	}
+	// Try object
+	var aux struct {
+		URL     string   `json:"url"`
+		Tags    []string `json:"tags"`
+		Primary bool     `json:"primary"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	r.URL = aux.URL
+	r.Tags = aux.Tags
+	r.Primary = aux.Primary
+	return nil
+}
+
+// MarshalJSON always serializes as an object with url key.
+func (r RepositoryEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		URL     string   `json:"url"`
+		Tags    []string `json:"tags,omitempty"`
+		Primary bool     `json:"primary,omitempty"`
+	}{URL: r.URL, Tags: r.Tags, Primary: r.Primary})
+}
+
+// PrimaryRepositoryURL returns the URL of the repo marked primary, or the
+// first repo URL if none is marked, or empty string if the list is empty.
+func PrimaryRepositoryURL(repos []RepositoryEntry) string {
+	for _, r := range repos {
+		if r.Primary {
+			return r.URL
+		}
+	}
+	if len(repos) > 0 {
+		return repos[0].URL
+	}
+	return ""
+}
+
 type Project struct {
 	Name         string            `json:"name" yaml:"name"`
 	Description  string            `json:"description" yaml:"description"`
 	MaturityLog  []MaturityEntry   `json:"maturity_log" yaml:"maturity_log"`
-	Repositories []string          `json:"repositories" yaml:"repositories"`
+	Repositories []RepositoryEntry `json:"repositories" yaml:"repositories"`
 	Social       map[string]string `json:"social" yaml:"social"`
 	Artwork      string            `json:"artwork" yaml:"artwork"`                       // Artwork URL
 	Website      string            `json:"website" yaml:"website"`                       // Project website URL

--- a/utilities/dot-project/validator.go
+++ b/utilities/dot-project/validator.go
@@ -326,10 +326,24 @@ func validateProjectStruct(project Project) []string {
 	if len(project.Repositories) == 0 {
 		errors = append(errors, "repositories is required and cannot be empty")
 	} else {
+		primaryRepoCount := 0
 		for i, repo := range project.Repositories {
-			if !isValidURL(repo) {
-				errors = append(errors, fmt.Sprintf("repositories[%d] is not a valid URL: %s", i, repo))
+			if repo.URL == "" {
+				errors = append(errors, fmt.Sprintf("repositories[%d] has an empty URL", i))
+			} else if !isValidURL(repo.URL) {
+				errors = append(errors, fmt.Sprintf("repositories[%d] is not a valid URL: %s", i, repo.URL))
 			}
+			for j, tag := range repo.Tags {
+				if tag == "" {
+					errors = append(errors, fmt.Sprintf("repositories[%d].tags[%d] must not be empty", i, j))
+				}
+			}
+			if repo.Primary {
+				primaryRepoCount++
+			}
+		}
+		if primaryRepoCount > 1 {
+			errors = append(errors, fmt.Sprintf("at most one repository may be marked primary, found %d", primaryRepoCount))
 		}
 	}
 

--- a/utilities/dot-project/validator_test.go
+++ b/utilities/dot-project/validator_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestValidator(t *testing.T) {
@@ -28,7 +30,7 @@ func TestValidator(t *testing.T) {
 				Issue: "https://github.com/cncf/toc/issues/123",
 			},
 		},
-		Repositories: []string{"https://github.com/test/repo"},
+		Repositories: []RepositoryEntry{{URL: "https://github.com/test/repo"}},
 		Website:      "https://test.io",
 		Artwork:      "https://test.io/artwork",
 		Audits: []Audit{
@@ -50,7 +52,7 @@ func TestValidator(t *testing.T) {
 		Name:         "",                // Missing required field
 		Description:  "",                // Missing required field
 		MaturityLog:  []MaturityEntry{}, // Empty required field
-		Repositories: []string{},        // Empty required field
+		Repositories: []RepositoryEntry{},        // Empty required field
 		Website:      "invalid-url",     // Invalid URL
 		Artwork:      "also-invalid",    // Invalid URL
 	}
@@ -142,16 +144,16 @@ func TestAuditsValidation(t *testing.T) {
 
 func TestRepositoriesValidation(t *testing.T) {
 	project := validBaseProject()
-	project.Repositories = []string{
-		"https://github.com/test/repo", // Valid
-		"invalid-url",                  // Invalid
-		"",                             // Empty
+	project.Repositories = []RepositoryEntry{
+		{URL: "https://github.com/test/repo"}, // Valid
+		{URL: "invalid-url"},                  // Invalid
+		{URL: ""},                             // Empty
 	}
 
 	errors := validateProjectStruct(project)
 	expectedErrors := []string{
 		"repositories[1] is not a valid URL: invalid-url",
-		"repositories[2] is not a valid URL: ",
+		"repositories[2] has an empty URL",
 	}
 
 	for _, expectedError := range expectedErrors {
@@ -165,6 +167,78 @@ func TestRepositoriesValidation(t *testing.T) {
 		if !found {
 			t.Errorf("Expected error '%s' not found in: %v", expectedError, errors)
 		}
+	}
+}
+
+func TestRepositoryEntryUnmarshal(t *testing.T) {
+	yamlInput := `repositories:
+  - "https://github.com/org/repo1"
+  - url: "https://github.com/org/repo2"
+    tags: [core, sig-apps]
+  - url: "https://github.com/org/repo3"
+`
+	var project struct {
+		Repositories []RepositoryEntry `yaml:"repositories"`
+	}
+	if err := yaml.Unmarshal([]byte(yamlInput), &project); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(project.Repositories) != 3 {
+		t.Fatalf("expected 3 repos, got %d", len(project.Repositories))
+	}
+	if project.Repositories[0].URL != "https://github.com/org/repo1" {
+		t.Errorf("repo[0] URL = %q", project.Repositories[0].URL)
+	}
+	if len(project.Repositories[0].Tags) != 0 {
+		t.Errorf("repo[0] should have no tags, got %v", project.Repositories[0].Tags)
+	}
+	if project.Repositories[1].URL != "https://github.com/org/repo2" {
+		t.Errorf("repo[1] URL = %q", project.Repositories[1].URL)
+	}
+	if len(project.Repositories[1].Tags) != 2 || project.Repositories[1].Tags[0] != "core" {
+		t.Errorf("repo[1] tags = %v", project.Repositories[1].Tags)
+	}
+	if project.Repositories[2].URL != "https://github.com/org/repo3" {
+		t.Errorf("repo[2] URL = %q", project.Repositories[2].URL)
+	}
+}
+
+func TestRepositoryEntryMarshal(t *testing.T) {
+	repos := []RepositoryEntry{
+		{URL: "https://github.com/org/plain"},
+		{URL: "https://github.com/org/tagged", Tags: []string{"core"}},
+	}
+	out, err := yaml.Marshal(struct {
+		Repositories []RepositoryEntry `yaml:"repositories"`
+	}{Repositories: repos})
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	output := string(out)
+	// Both entries should have url: key
+	if strings.Count(output, "url:") != 2 {
+		t.Errorf("expected 2 url: keys in output:\n%s", output)
+	}
+	// Only tagged entry should have tags
+	if strings.Count(output, "tags:") != 1 {
+		t.Errorf("expected 1 tags: key in output:\n%s", output)
+	}
+}
+
+func TestRepositoryEntryTagsValidation(t *testing.T) {
+	project := validBaseProject()
+	project.Repositories = []RepositoryEntry{
+		{URL: "https://github.com/test/repo", Tags: []string{"valid", ""}},
+	}
+	errors := validateProjectStruct(project)
+	found := false
+	for _, e := range errors {
+		if e == "repositories[0].tags[1] must not be empty" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected empty tag error, got: %v", errors)
 	}
 }
 


### PR DESCRIPTION
Resolving issue https://github.com/cncf/automation/issues/576

* Expanded repo schema to include `tags` and `primary`
* The automation detects the primary from 3 sources: 
  - naming convention (repo matches the org name, like helm/helm - org/repo)
  - Or we check landscape.yml -> repo_url field
  - Or the first pinned repo in the Org. 
  
  
I couldn't find a place where the tags are defined. K8s has a `sigs.yml` file, but I didn't find other Orgs that have this convention, therefor they need to be specified manually by whoever audits the `project.yml`. We always surface the tag for at least one repo as a comment for visibility.
 