### PR TITLE
feat: add managed flag to maintainer teams for flexible resource provisioning

### DIFF
--- a/utilities/dot-project/SCHEMA.md
+++ b/utilities/dot-project/SCHEMA.md
@@ -199,14 +199,15 @@ PathRef values should be **full GitHub URLs** (e.g., `https://github.com/org/rep
 |-------|------|----------|-------------|-------------|
 | `project_id` | string | Yes | Project slug | Must match `slug` in project.yaml |
 | `org` | string | No | GitHub organization | |
-| `teams` | Team[] | Yes | Team definitions | Must include `project-maintainers` team |
+| `teams` | Team[] | Yes | Team definitions | At least one managed team required |
 
 ### Team
 
 | Field | Type | Required | Description | Constraints |
 |-------|------|----------|-------------|-------------|
-| `name` | string | Yes | Team name | `project-maintainers` is required |
-| `members` | string[] | Yes | GitHub handles | Non-empty for `project-maintainers`; normalized (trimmed, `@` stripped) |
+| `name` | string | Yes | Team name | Any descriptive name (e.g., `maintainers`, `committers`, `reviewers`, `emeritus`) |
+| `members` | string[] | Yes | GitHub handles | At least one managed team must have members; normalized (trimmed, `@` stripped) |
+| `managed` | bool | No | Whether team is provisioned to CNCF resources | Defaults to `true` if omitted. Teams with `managed: false` are excluded from handle verification, mailing lists, service desk, and Copilot seat provisioning |
 
 ## Validation Rules
 
@@ -216,4 +217,4 @@ PathRef values should be **full GitHub URLs** (e.g., `https://github.com/org/rep
 4. **Slug format** -- lowercase letters, digits, and hyphens; no leading/trailing hyphens
 5. **Maturity ordering** -- maturity_log entries must be in chronological order
 6. **Handle normalization** -- leading `@` and whitespace are stripped; duplicates are detected case-insensitively
-7. **Required teams** -- every maintainer entry must include a `project-maintainers` team with at least one member
+7. **Required managed team** -- every maintainer entry must include at least one team with `managed: true` (or `managed` omitted) that has at least one member

--- a/utilities/dot-project/bootstrap_scaffold.go
+++ b/utilities/dot-project/bootstrap_scaffold.go
@@ -118,11 +118,25 @@ maintainers:
     {{ if .GitHubOrg }}org: "{{ .GitHubOrg }}"{{ else }}# TODO: Set GitHub organization
     # org: "my-org"{{ end }}
     teams:
-      - name: "project-maintainers"
+      - name: "maintainers"
         members:{{ if .Maintainers }}{{ range .Maintainers }}
           - {{ . }}{{ end }}{{ else }}
           # TODO: Add maintainer handles
           - github-handle{{ end }}
+      # Unmanaged teams: teams with "managed: false" are tracked in this
+      # file for documentation but are excluded from CNCF resource
+      # provisioning (mailing lists, service desk, Copilot seats, etc).
+      #
+      # Active contributors who do not need full CNCF resource access:
+      # - name: "reviewers"
+      #   managed: false
+      #   members:
+      #     - reviewer-handle
+      #
+      # Former maintainers (remove this section if not applicable):
+      # - name: "emeritus"
+      #   managed: false
+      #   members: []
 `
 
 // readmeTemplate generates the README.md for the .project directory.

--- a/utilities/dot-project/maintainers.go
+++ b/utilities/dot-project/maintainers.go
@@ -57,6 +57,10 @@ func (pv *ProjectValidator) ExtractHandles(path string) (map[string]bool, error)
 	handles := make(map[string]bool)
 	for _, entry := range config.Maintainers {
 		for _, team := range entry.Teams {
+			// Only extract handles from managed teams for resource provisioning
+			if !team.IsManaged() {
+				continue
+			}
 			for _, member := range team.Members {
 				trimmed := strings.TrimSpace(member)
 				trimmed = strings.TrimPrefix(trimmed, "@")
@@ -83,16 +87,22 @@ func (pv *ProjectValidator) validateMaintainerEntry(entry MaintainerEntry, verif
 		result.Errors = append(result.Errors, "teams list cannot be empty")
 	}
 
-	hasProjectMaintainers := false
+	hasManagedTeam := false
+	managedTeamHasMembers := false
 	var allVerifiedHandles []string
 	allPassed := true
 
 	for _, team := range entry.Teams {
-		if team.Name == "project-maintainers" {
-			hasProjectMaintainers = true
-			if len(team.Members) == 0 {
-				result.Errors = append(result.Errors, "team 'project-maintainers' cannot be empty")
+		if team.IsManaged() {
+			hasManagedTeam = true
+			if len(team.Members) > 0 {
+				managedTeamHasMembers = true
 			}
+		}
+
+		// Skip handle verification for unmanaged teams
+		if !team.IsManaged() {
+			continue
 		}
 
 		cleanHandles, duplicateErrors := normalizeHandles(team.Members)
@@ -118,8 +128,10 @@ func (pv *ProjectValidator) validateMaintainerEntry(entry MaintainerEntry, verif
 		}
 	}
 
-	if !hasProjectMaintainers {
-		result.Errors = append(result.Errors, "team 'project-maintainers' is required")
+	if !hasManagedTeam {
+		result.Errors = append(result.Errors, "at least one managed team is required (set managed: true or omit the managed field)")
+	} else if !managedTeamHasMembers {
+		result.Errors = append(result.Errors, "at least one managed team must have members")
 	}
 
 	if result.VerificationAttempted {

--- a/utilities/dot-project/maintainers_format_test.go
+++ b/utilities/dot-project/maintainers_format_test.go
@@ -112,7 +112,7 @@ func TestFormatMaintainersText(t *testing.T) {
 			{
 				ProjectID: "bad-project",
 				Valid:     false,
-				Errors:    []string{"project_id is required", "team 'project-maintainers' is required"},
+				Errors:    []string{"project_id is required", "at least one managed team is required (set managed: true or omit the managed field)"},
 			},
 			{ProjectID: "another-good", Valid: true},
 		}
@@ -131,8 +131,8 @@ func TestFormatMaintainersText(t *testing.T) {
 		if !strings.Contains(out, "  - project_id is required") {
 			t.Error("missing error bullet: project_id is required")
 		}
-		if !strings.Contains(out, "  - team 'project-maintainers' is required") {
-			t.Error("missing error bullet: team 'project-maintainers' is required")
+		if !strings.Contains(out, "  - at least one managed team is required") {
+			t.Error("missing error bullet: at least one managed team is required")
 		}
 		// Summary line
 		if !strings.Contains(out, "Summary: 3 maintainer entries validated, 1 with issues") {
@@ -460,7 +460,7 @@ func TestValidateMaintainersWithExclusion(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // validateMaintainerEntry – cover missing project_id, empty teams, no
-// project-maintainers team, and exclusion within the entry.
+// managed team, managed flag behavior, and exclusion within the entry.
 // ---------------------------------------------------------------------------
 
 func TestValidateMaintainerEntry(t *testing.T) {
@@ -476,7 +476,7 @@ func TestValidateMaintainerEntry(t *testing.T) {
 		entry := MaintainerEntry{
 			ProjectID: "",
 			Teams: []Team{
-				{Name: "project-maintainers", Members: []string{"alice"}},
+				{Name: "maintainers", Members: []string{"alice"}},
 			},
 		}
 		result := pv.validateMaintainerEntry(entry, false, nil)
@@ -505,66 +505,67 @@ func TestValidateMaintainerEntry(t *testing.T) {
 			t.Fatal("expected invalid result for empty teams")
 		}
 		foundEmpty := false
-		foundMissing := false
+		foundManaged := false
 		for _, e := range result.Errors {
 			if strings.Contains(e, "teams list cannot be empty") {
 				foundEmpty = true
 			}
-			if strings.Contains(e, "team 'project-maintainers' is required") {
-				foundMissing = true
+			if strings.Contains(e, "at least one managed team is required") {
+				foundManaged = true
 			}
 		}
 		if !foundEmpty {
 			t.Errorf("expected 'teams list cannot be empty' error, got: %v", result.Errors)
 		}
-		if !foundMissing {
-			t.Errorf("expected 'project-maintainers is required' error, got: %v", result.Errors)
+		if !foundManaged {
+			t.Errorf("expected 'at least one managed team is required' error, got: %v", result.Errors)
 		}
 	})
 
-	t.Run("no project-maintainers team", func(t *testing.T) {
+	t.Run("only unmanaged teams", func(t *testing.T) {
+		managedFalse := false
 		entry := MaintainerEntry{
 			ProjectID: "proj",
 			Teams: []Team{
-				{Name: "reviewers", Members: []string{"alice"}},
+				{Name: "emeritus", Members: []string{"alice"}, Managed: &managedFalse},
 			},
 		}
 		result := pv.validateMaintainerEntry(entry, false, nil)
 		if result.Valid {
-			t.Fatal("expected invalid when project-maintainers team is missing")
+			t.Fatal("expected invalid when no managed team exists")
 		}
 		found := false
 		for _, e := range result.Errors {
-			if strings.Contains(e, "team 'project-maintainers' is required") {
+			if strings.Contains(e, "at least one managed team is required") {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("expected 'project-maintainers is required' error, got: %v", result.Errors)
+			t.Errorf("expected 'at least one managed team is required' error, got: %v", result.Errors)
 		}
 	})
 
-	t.Run("empty project-maintainers team", func(t *testing.T) {
+	t.Run("managed team with no members", func(t *testing.T) {
 		entry := MaintainerEntry{
 			ProjectID: "proj",
 			Teams: []Team{
-				{Name: "project-maintainers", Members: []string{}},
+				{Name: "maintainers", Members: []string{}},
 			},
 		}
 		result := pv.validateMaintainerEntry(entry, false, nil)
 		if result.Valid {
-			t.Fatal("expected invalid when project-maintainers has no members")
+			t.Fatal("expected invalid when managed team has no members")
 		}
 		found := false
 		for _, e := range result.Errors {
-			if strings.Contains(e, "team 'project-maintainers' cannot be empty") {
+			if strings.Contains(e, "at least one managed team must have members") {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("expected 'project-maintainers cannot be empty' error, got: %v", result.Errors)
+			t.Errorf("expected 'at least one managed team must have members' error, got: %v", result.Errors)
 		}
 	})
 
@@ -572,7 +573,7 @@ func TestValidateMaintainerEntry(t *testing.T) {
 		entry := MaintainerEntry{
 			ProjectID: "proj",
 			Teams: []Team{
-				{Name: "project-maintainers", Members: []string{"alice", "bob"}},
+				{Name: "maintainers", Members: []string{"alice", "bob"}},
 			},
 		}
 		result := pv.validateMaintainerEntry(entry, false, nil)
@@ -584,6 +585,45 @@ func TestValidateMaintainerEntry(t *testing.T) {
 		}
 	})
 
+	t.Run("backward compat: project-maintainers team name still valid", func(t *testing.T) {
+		entry := MaintainerEntry{
+			ProjectID: "proj",
+			Teams: []Team{
+				{Name: "project-maintainers", Members: []string{"alice"}},
+			},
+		}
+		result := pv.validateMaintainerEntry(entry, false, nil)
+		if !result.Valid {
+			t.Errorf("expected valid result for project-maintainers team, got errors: %v", result.Errors)
+		}
+	})
+
+	t.Run("unmanaged teams skipped from verification", func(t *testing.T) {
+		t.Setenv("LFX_AUTH_TOKEN", "")
+		t.Setenv("MAINTAINER_API_ENDPOINT", "https://example.com/api")
+		t.Setenv("MAINTAINER_API_STUB", "fail")
+
+		managedFalse := false
+		entry := MaintainerEntry{
+			ProjectID: "proj",
+			Teams: []Team{
+				{Name: "maintainers", Members: []string{"alice"}},
+				{Name: "emeritus", Members: []string{"should-not-verify"}, Managed: &managedFalse},
+			},
+		}
+		// "fail" stub means any verified handle will fail — but emeritus should be skipped
+		result := pv.validateMaintainerEntry(entry, true, nil)
+		if result.VerificationPassed {
+			t.Error("expected verification to fail for managed team with stub=fail")
+		}
+		// Verify emeritus handle was NOT attempted
+		for _, e := range result.Errors {
+			if strings.Contains(e, "should-not-verify") {
+				t.Error("unmanaged team member should not be verified")
+			}
+		}
+	})
+
 	t.Run("verification with exclusion skips excluded handles", func(t *testing.T) {
 		t.Setenv("LFX_AUTH_TOKEN", "")
 		t.Setenv("MAINTAINER_API_ENDPOINT", "https://example.com/api")
@@ -592,7 +632,7 @@ func TestValidateMaintainerEntry(t *testing.T) {
 		entry := MaintainerEntry{
 			ProjectID: "proj",
 			Teams: []Team{
-				{Name: "project-maintainers", Members: []string{"alice", "bob", "carol"}},
+				{Name: "maintainers", Members: []string{"alice", "bob", "carol"}},
 			},
 		}
 		excluded := map[string]bool{"alice": true, "carol": true}
@@ -614,7 +654,7 @@ func TestValidateMaintainerEntry(t *testing.T) {
 		entry := MaintainerEntry{
 			ProjectID: "proj",
 			Teams: []Team{
-				{Name: "project-maintainers", Members: []string{"alice"}},
+				{Name: "maintainers", Members: []string{"alice"}},
 			},
 		}
 		result := pv.validateMaintainerEntry(entry, true, nil)

--- a/utilities/dot-project/template/maintainers.yaml
+++ b/utilities/dot-project/template/maintainers.yaml
@@ -5,11 +5,26 @@ maintainers:
   - project_id: "my-project"    # Must match slug in project.yaml
     org: "my-org"               # GitHub organization (optional)
     teams:
-      - name: "project-maintainers"  # REQUIRED team
+      - name: "maintainers"
         members:
           - github-handle-1
           - github-handle-2
       # Additional teams are optional
+      # - name: "committers"
+      #   members:
+      #     - committer-handle
+      #
+      # Unmanaged teams: teams with "managed: false" are tracked here for
+      # documentation but are excluded from CNCF resource provisioning
+      # (mailing lists, service desk, Copilot seats, handle verification).
+      #
+      # Active contributors who do not need full CNCF resource access:
       # - name: "reviewers"
+      #   managed: false
       #   members:
       #     - reviewer-handle
+      #
+      # Former maintainers (remove this section if not applicable):
+      # - name: "emeritus"
+      #   managed: false
+      #   members: []

--- a/utilities/dot-project/types.go
+++ b/utilities/dot-project/types.go
@@ -291,10 +291,20 @@ type MaintainerEntry struct {
 	Teams     []Team `json:"teams" yaml:"teams"`
 }
 
-// Team represents a GitHub team and its members
+// Team represents a GitHub team and its members.
+// Teams with Managed set to false are excluded from CNCF resource provisioning
+// (handle verification, mailing lists, service desk, Copilot seats).
+// If Managed is nil (omitted), the team is treated as managed by default.
 type Team struct {
 	Name    string   `json:"name" yaml:"name"`
 	Members []string `json:"members" yaml:"members"`
+	Managed *bool    `json:"managed,omitempty" yaml:"managed,omitempty"`
+}
+
+// IsManaged returns true if the team should be included in CNCF resource
+// automation. A nil Managed field defaults to true (backward compatible).
+func (t Team) IsManaged() bool {
+	return t.Managed == nil || *t.Managed
 }
 
 // MaintainerLifecycle represents maintainer lifecycle documentation


### PR DESCRIPTION
* Added a `managed` flag to control whether the dot-project automation provisions the team with CNCF resources. It's a binary gate, so either full access to CNCF resources or no access. 

* Added a default commented-out team that represents the `alumni` or the `emeritus` with the `managed` flag pre-set to false.

* Added another commented-out team that represents active maintainers but shouldn't have access to CNCF resources, with the managed flag pre-set to false. (added this and the above point to the template for visibilty only)

* Removed the validation of the name "project-maintainers" and replaced it with "at least one managed team is required"

A newly onboarded org with the above changes included: https://github.com/volcano-sh/.project/blob/main/maintainers.yaml