### PR TITLE
ci/gha-runner-vm: install witness and sbomit into the runner image

### DIFF
--- a/ci/gha-runner-vm/main.go
+++ b/ci/gha-runner-vm/main.go
@@ -146,6 +146,10 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	baseDir := strings.Split(filename, "/")[0]
 	installRunnerPackage(baseDir)
+	// call installSBOMitTools to create the install script
+	if err := installSBOMitTools(baseDir); err != nil {
+		log.Fatalf("Failed to create SBOMit tools install script: %v", err)
+	}
 
 	updatePackerConfig(baseDir, "/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1", ".*Get-GHCupVersion.*", "")
 	updatePackerConfig(baseDir, "/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1", ".*Get-FastlaneVersion.*", "")
@@ -530,6 +534,61 @@ mv "$archive_path" "/opt/runner-cache/$archive_name"
 	return nil
 }
 
+// installSBOMitTools writes the install script for the SBOMit toolchain
+// (witness, sbomit) into the runner-images build scripts directory.
+// The script is registered with the build provisioner via the replacements map in init().
+func installSBOMitTools(baseDir string) error {
+	log.Println("Creating SBOMit tools installation script...")
+
+	scriptContent := `#!/bin/bash -e
+################################################################################
+##  File:  install-sbomit-tools.sh
+##  Desc:  Build and install the SBOMit toolchain (witness, sbomit)
+################################################################################
+
+# Go is installed into the runner-images toolcache, not a fixed prefix, and the
+# toolset PATH is not visible to this non-login provisioner shell.
+if ! command -v go >/dev/null; then
+  go_bin=$(ls -d /opt/hostedtoolcache/go/*/*/bin 2>/dev/null | sort -V | tail -n1)
+  [ -n "$go_bin" ] && export PATH="$PATH:$go_bin"
+fi
+command -v go >/dev/null || { echo "go toolchain not found on PATH"; exit 1; }
+go version
+
+build_dir=$(mktemp -d)
+
+# --- witness -----------------------------------------------------------------
+# Built from source: the required ptrace fixes are not in a tagged release yet.
+git clone https://github.com/in-toto/witness.git "$build_dir/witness"
+git clone https://github.com/in-toto/go-witness.git "$build_dir/go-witness"
+
+cd "$build_dir/witness"
+go work init .
+go work use ../go-witness
+make build
+install -m 0755 ./bin/witness /usr/local/bin/witness
+
+# --- sbomit ------------------------------------------------------------------
+# GOBIN is set explicitly; otherwise this lands in root's GOPATH, which is not
+# on the runner user's PATH.
+GOBIN=/usr/local/bin go install github.com/sbomit/sbomit@latest
+
+# --- verify ------------------------------------------------------------------
+witness version
+command -v sbomit
+sbomit --help | head -n 1
+
+`
+
+	scriptPath := baseDir + "/images/ubuntu/scripts/build/install-sbomit-tools.sh"
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0755); err != nil {
+		return fmt.Errorf("failed to create install-sbomit-tools.sh: %w", err)
+	}
+
+	log.Println("SBOMit tools installation script created successfully")
+	return nil
+}
+
 func init() {
 	flags := Cmd.Flags()
 
@@ -694,4 +753,16 @@ build {
 
 	replacements[`destination = "${path.root}/../software-report.json"`] = `only = ["azure-arm.build_image"]
 			destination = "${path.root}/../software-report.json"`
+
+	// The SBOMit toolchain must be installed after the toolset provisioner which is where the Go toolchain is installed.
+	toolsetProvisioner := `    scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
+  }`
+
+	sbomitProvisioner := `  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-sbomit-tools.sh"]
+  }`
+
+	replacements[toolsetProvisioner] = toolsetProvisioner + "\n\n" + sbomitProvisioner
 }

--- a/ci/gha-runner-vm/main.go
+++ b/ci/gha-runner-vm/main.go
@@ -730,7 +730,8 @@ build {
   }`
 
 	replacements[`"${path.root}/../scripts/build/install-actions-cache.sh",`] = `"${path.root}/../scripts/build/install-actions-cache.sh",
-				"${path.root}/../scripts/build/install-runner-package.sh",`
+				"${path.root}/../scripts/build/install-runner-package.sh",
+				"${path.root}/../scripts/build/install-sbomit-tools.sh",`
 
 	replacements[`sources = ["source.azure-arm.build_image"]`] = `sources = ["source.azure-arm.build_image", "source.qemu.img"]
 		provisioner "shell" {
@@ -753,16 +754,4 @@ build {
 
 	replacements[`destination = "${path.root}/../software-report.json"`] = `only = ["azure-arm.build_image"]
 			destination = "${path.root}/../software-report.json"`
-
-	// The SBOMit toolchain must be installed after the toolset provisioner which is where the Go toolchain is installed.
-	toolsetProvisioner := `    scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
-  }`
-
-	sbomitProvisioner := `  provisioner "shell" {
-    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
-    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    scripts          = ["${path.root}/../scripts/build/install-sbomit-tools.sh"]
-  }`
-
-	replacements[toolsetProvisioner] = toolsetProvisioner + "\n\n" + sbomitProvisioner
 }


### PR DESCRIPTION
## Summary

This PR adds SBOMit tools (`witness` and `sbomit`) to the GHA runner VM image.

Both tools are installed to `/usr/local/bin`, so any job running on the image can call them directly.

---

## Changes

There are three changes in `ci/gha-runner-vm/main.go`.

### A. New function `installSBOMitTools`

This writes a new script, `install-sbomit-tools.sh`, into the runner-images build scripts directory. It follows the same pattern as the existing `installRunnerPackage` function.

Three parts of the script may need explanation.

**1. Finding Go.**
Go is not installed by a build script. It comes from the toolset provisioner and lands in the runner-images toolcache, so there is no fixed prefix like `/usr/local/go`. The PATH that `Configure-Toolset.ps1` sets is also not visible here, because the provisioner runs the script through `sudo sh -c`, which is a non-login shell. The script therefore looks for Go under `/opt/hostedtoolcache/go` before building. If Go is already on PATH, this block is skipped.

**2. Building witness.**
This is where the witness binary is built.

**3. Building sbomit.**
This is where the sbomit binary is built. `go install` has no destination argument, so `GOBIN` decides where the binary goes. The script runs as root, so without `GOBIN` the binary would land in root's `GOPATH` and would not be on the runner user's PATH. `witness` does not need this, because `install -m 0755` already names the destination.

### B. Call to `installSBOMitTools`

Called in `run()`, right after `installRunnerPackage(baseDir)`. This only creates the script file.

### C. New entry in the `replacements` map

This registers the script with a new `provisioner "shell"` block in the packer template. Without this, the script file exists, but packer never runs it.

The new provisioner is placed right after the toolset provisioner.

---

## Testing

I ran the static checks `gofmt`, `go build`, and `go vet`.

I also tried to run a full packer build to check whether the binaries actually get installed. But resolving all the build dependencies took too long, so I was not able to finish it locally.

If someone on the CNCF side could confirm just this part, I would really appreciate it. The script prints `go version`, `witness version`, and the path of `sbomit`, so a build log should be enough to tell whether it worked.

---

## Open questions

**1. Is the toolcache path for Go correct?**
We inferred the layout under `/opt/hostedtoolcache/go` from `AGENT_TOOLSDIRECTORY` and from how other tools are laid out. We did not observe it directly.

**2. Is this the right way to add a provisioner?**
If you prefer a different way of appending provisioners, we are happy to change it.

/kind enhancement
/priority medium
/area ci
/status needs-review