### PR TITLE
fix: ssh retry double-increment; bump landscape-sync go-github to v71

### DIFF
--- a/ci/cloudrunners/pkg/remote/client.go
+++ b/ci/cloudrunners/pkg/remote/client.go
@@ -32,7 +32,6 @@ func DialWithRetry(ctx context.Context, network, addr string, sshConfig *ssh.Cli
 			return nil, fmt.Errorf("failed to connect to ssh on %q: %w", addr, err)
 		}
 		log.Info("retrying ssh connection", "attempt", attempt, "error", err)
-		attempt++
 		time.Sleep(2 * time.Second)
 	}
 }

--- a/utilities/landscape-sync/go.mod
+++ b/utilities/landscape-sync/go.mod
@@ -3,7 +3,7 @@ module github.com/cncf/automation/utilities/landscape-sync
 go 1.27.1
 
 require (
-	github.com/google/go-github/v60 v60.0.0
+	github.com/google/go-github/v71 v71.0.0
 	golang.org/x/oauth2 v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/utilities/landscape-sync/go.sum
+++ b/utilities/landscape-sync/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v60 v60.0.0 h1:oLG98PsLauFvvu4D/YPxq374jhSxFYdzQGNCyONLfn8=
-github.com/google/go-github/v60 v60.0.0/go.mod h1:ByhX2dP9XT9o/ll2yXAu2VD8l5eNVg8hD4Cr0S/LmQk=
+github.com/google/go-github/v71 v71.0.0 h1:Zi16OymGKZZMm8ZliffVVJ/Q9YZreDKONCr+WUd0Z30=
+github.com/google/go-github/v71 v71.0.0/go.mod h1:URZXObp2BLlMjwu0O8g4y6VBneUj2bCHgnI8FfgZ51M=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 golang.org/x/oauth2 v0.37.0 h1:JUlcxA8oAtauLfiH8FX2/FkAWHAdi0QtGCGc+hofE98=

--- a/utilities/landscape-sync/main.go
+++ b/utilities/landscape-sync/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v60/github"
+	"github.com/google/go-github/v71/github"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 )


### PR DESCRIPTION
Part of an ongoing effort to clean up, consolidate, and prune this repo (follows #664, #668).

- `ci/cloudrunners/pkg/remote/client.go` — `DialWithRetry` incremented `attempt` twice per loop, so `maxAttempts=99` was effectively ~50 and logged attempt numbers were odd-only. Removed the stray increment.
- `utilities/landscape-sync` — `go-github` v60 → v71, aligning with `gha-runner-vm`/`gha-runner-vm-oci`. Drops the deprecated `google.golang.org/appengine` + `golang/protobuf` transitive chain. No API changes needed.

Verified locally with `go vet` on both modules. Heads-up: this touches the same import line as #648, so whichever merges second needs a trivial rebase.
