### PR TITLE
docs: align dot-project docs with managed team flag convention

### DIFF
--- a/utilities/dot-project/AGENT.md
+++ b/utilities/dot-project/AGENT.md
@@ -397,11 +397,12 @@ maintainers:
   - project_id: "project-id"
     org: "github-org"  # optional
     teams:
-      - name: "project-maintainers"  # required team
+      - name: "maintainers"  # managed: true by default; at least one managed team is required
         members:
           - alice
           - bob
-      - name: "other-team"
+      - name: "emeritus"
+        managed: false        # excluded from handle verification and CNCF resource provisioning
         members:
           - carol
 ```

--- a/utilities/dot-project/README.md
+++ b/utilities/dot-project/README.md
@@ -403,13 +403,13 @@ docker run --rm --entrypoint landscape-updater dot-project-validator --help
 maintainers:
   - project_id: "your-project"
     teams:
-      - name: "project-maintainers"
+      - name: "maintainers"
         members:
           - githubuser1
           - githubuser2
 ```
 
-Each maintainer entry must contain a `project-maintainers` team which cannot be empty. Handles are normalized (trimmed and stripped of leading `@`) before verification.
+Each maintainer entry must contain at least one team with `managed: true` (the default when `managed` is omitted) that has at least one member. Team names are free-form (e.g. `maintainers`, `committers`, `reviewers`, `emeritus`); set `managed: false` on teams that should be tracked but excluded from CNCF resource provisioning (handle verification, mailing lists, service desk, Copilot seats). Handles are normalized (trimmed and stripped of leading `@`) before verification.
 
 3. **Add GitHub Actions** to automatically validate changes (see GitHub Actions section above).
 

--- a/utilities/dot-project/example/maintainers.yaml
+++ b/utilities/dot-project/example/maintainers.yaml
@@ -7,7 +7,7 @@ maintainers:
   - project_id: "kubernetes"     # Must match slug in project.yaml
     org: "kubernetes"            # GitHub organization
     teams:
-      - name: "project-maintainers"
+      - name: "maintainers"
         members:
           - thockin
           - liggitt


### PR DESCRIPTION
README.md, example/maintainers.yaml, and AGENT.md still referenced the old hard-required 'project-maintainers' team name and rule, which was superseded by PR cncf/automation#602 (managed flag for flexible resource provisioning). SCHEMA.md and template/maintainers.yaml were updated by that PR but these three files were missed.

- README.md: update sample maintainers.yaml and required-team wording to describe the 'at least one managed team' rule and managed:false semantics (excluded from handle verification, mailing lists, service desk, Copilot seats).
- example/maintainers.yaml: rename the Kubernetes example's required team from project-maintainers to maintainers, matching template/.
- AGENT.md: update the sample maintainers config to use the maintainers team name and demonstrate an emeritus team with managed: false.