### PR TITLE
Add wrap runner run.sh with witness

### DIFF
--- a/ci/cloudrunners/oci/main.go
+++ b/ci/cloudrunners/oci/main.go
@@ -366,7 +366,26 @@ func runOnMachine(ctx context.Context, machine *oci.EphemeralMachine, sshKeyPair
 		"sudo setfacl -m u:ubuntu:rw /var/run/docker.sock",
 		"sudo sysctl fs.inotify.max_user_instances=1280",
 		"sudo sysctl fs.inotify.max_user_watches=655360",
-		"export PATH=$PATH:/home/ubuntu/.local/bin:/home/ubuntu/.cargo/bin:/home/ubuntu/.rustup/bin && export HOME=/home/ubuntu && export NVM_DIR=/home/ubuntu/.nvm && bash -x /home/ubuntu/run.sh --jitconfig \"${ACTIONS_RUNNER_INPUT_JITCONFIG}\"",
+		// Run the GitHub Actions runner under witness to record an attestation of the job.
+		"export PATH=$PATH:/home/ubuntu/.local/bin:/home/ubuntu/.cargo/bin:/home/ubuntu/.rustup/bin && export HOME=/home/ubuntu && export NVM_DIR=/home/ubuntu/.nvm" +
+			// Directory for witness files, and the runner work directory used as the witness working directory.
+			" && mkdir -p /tmp/witness /home/ubuntu/_work" +
+			// Key used to sign the attestation.
+			" && openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out /tmp/witness/key.pem" +
+			// CA for network tracing, added to the system trust store so TLS clients in the job accept it.
+			" && openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj \"/CN=witness-network-trace-ca\" -keyout /tmp/witness/ca.key -out /tmp/witness/ca.crt" +
+			" && sudo cp /tmp/witness/ca.crt /usr/local/share/ca-certificates/witness-network-trace-ca.crt && sudo update-ca-certificates" +
+			// witness runs as root.
+			" && sudo -E witness run --step gha-job" +
+			" --trace --attestor-command-run-trace-backend ebpf" +
+			" -a network-trace" +
+			" --attestor-network-trace-generate-ca=false" +
+			" --attestor-network-trace-ca-cert-path /tmp/witness/ca.crt" +
+			" --attestor-network-trace-ca-key-path /tmp/witness/ca.key" +
+			// Signing key, attestation output path, and working directory.
+			" --signer-file-key-path /tmp/witness/key.pem" +
+			" -o /tmp/witness/attestation.json --workingdir /home/ubuntu/_work" +
+			" -- sudo -E -u ubuntu env PATH=\"$PATH\" HOME=/home/ubuntu NVM_DIR=/home/ubuntu/.nvm bash -x /home/ubuntu/run.sh --jitconfig \"${ACTIONS_RUNNER_INPUT_JITCONFIG}\"",
 	}
 
 	for _, cmd := range commands {


### PR DESCRIPTION
## Summary

This PR wraps the GitHub Actions runner with `witness run`, so that the VM produces in-toto attestation.

This PR only covers invoking `witness` on the VM. This is a follow-up to #639.

## Changes

Only the last command in `runOnMachine()` (`cloudrunners/oci/main.go`) is changed. 
The command now does the following in order.

1. Sets up the runner environment (unchanged from the command).
2. Creates `/tmp/witness` for witness files and `/home/ubuntu/_work` as the witness working directory.
3. Generates signing key for the attestation.
4. Generates CA for network tracing and adds it to the system trust store.
5. Runs `witness run` as root.
6. Starts `run.sh` as `ubuntu` under witness, as before.

The resulting process tree

```
witness run (root)
└─ sudo -u ubuntu
   └─ bash -x run.sh
      └─ Runner.Listener
         └─ Runner.Worker
            └─ job steps
```

The attestation is stored at `/tmp/witness/attestation.json` on the VM.

## Questions
**1. Could you check the kernel version of the OCI image?**
The network trace requires kernel 6.12 or later. The kernel version of the current OCI image has not been confirmed.

**2. Is there another way to call the witness binary on the VM from this file?**
In the current code, witness wraps the whole job, including the runner agent and all steps. However, we only want to monitor the job steps inside run.sh. If you have any other ideas, please let me know. Also, wrapping it this way will likely include ACTIONS_RUNNER_INPUT_JITCONFIG in the attestation.

**3. Could you also review where the attestation should be saved?**
The attestation will be used as input for the sbomit binary. This PR only changes the first step of the SBOMit pipeline (calling witness), but later we will need the path to this attestation file when running sbomit. In addition, it would be great to discuss how we plan to collect the final SBOM file once it is generated.

----
/kind enhancement
/area ci
/priority medium
/status needs-review