### PR TITLE
Fix broken CONTRIBUTING.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ workflow run also uploads a `tooling-sbom-<sha>` artifact. Regenerate locally wi
 
 ## Contributing
 
-Contributions to improve these automation tools are welcome! Please see our [contributing guidelines](CONTRIBUTING.md) for more details.
+Contributions to improve these automation tools are welcome! Please see our [contributing guidelines](.github/CONTRIBUTING.md) for more details.
 
 ## License
 


### PR DESCRIPTION
Fixes the broken relative link to CONTRIBUTING.md in the root README.md.

Since CONTRIBUTING.md actually lives at .github/CONTRIBUTING.md, the
previous link (CONTRIBUTING.md) resolved to a 404. Updated it to
.github/CONTRIBUTING.md.

Related to #678