### PR TITLE
HOME does not work well, change to github.workspace

### DIFF
--- a/.github/actions/setup-oci-cli/action.yml
+++ b/.github/actions/setup-oci-cli/action.yml
@@ -60,9 +60,9 @@ runs:
           fi
         done
         umask 077
-        mkdir -p "$HOME/.oci"
-        CONFIG_FILE="$HOME/.oci/config"
-        KEY_FILE="$HOME/.oci/oci_api_key.pem"
+        mkdir -p "${{ github.workspace }}/.oci"
+        CONFIG_FILE="${{ github.workspace }}/.oci/config"
+        KEY_FILE="${{ github.workspace }}/.oci/oci_api_key.pem"
 
         printf '%s\n' "$OCI_KEY_CONTENT" > "$KEY_FILE"
         cat > "$CONFIG_FILE" <<EOF

--- a/.github/workflows/build-actions-vm.yml
+++ b/.github/workflows/build-actions-vm.yml
@@ -116,6 +116,8 @@ jobs:
       - name: Build VM Images
         if: steps.check_latest.outputs.image_exists == 'false'
         id: build_image
+        env:
+          OCI_CONFIG_FILE: ${{ steps.oci.outputs.config-file }}
         run: |
           set -euo pipefail
           export PATH="$PATH:$HOME/.local/bin:$HOME/bin" && \


### PR DESCRIPTION
To fix the failure of the raw request, e.g., https://github.com/cncf/automation/actions/runs/34570462842/job/103368369827

The `$HOME` does not work well, changing to `${{ github.workspace }}`